### PR TITLE
Fix evaluation data path case-sensitivity

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -8,7 +8,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 # 데이터 파일 위치(배포시 함께 넣는 상대 경로)
 DATA_DIR = PROJECT_ROOT / "data"
 TRAIN_PATH = str((DATA_DIR / "train.csv").resolve())
-EVAL_PATH  = str((DATA_DIR / "Test_00.csv").resolve())
+EVAL_PATH  = str((DATA_DIR / "TEST_00.csv").resolve())
 
 # 산출물 저장 루트(자동 생성)
 ARTIFACTS_DIR = PROJECT_ROOT / "artifacts"


### PR DESCRIPTION
## Summary
- use correct uppercase filename for evaluation data path

## Testing
- `python -m py_compile LGHackerton/config/default.py`
- `python - <<'PY'
import os
from LGHackerton.config.default import EVAL_PATH
print('EVAL_PATH:', EVAL_PATH)
print('Exists?', os.path.exists(EVAL_PATH))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689efefdbe4083288c3e764d8c80c74d