### PR TITLE
Implement time-aware validation for PatchTST

### DIFF
--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -27,7 +27,7 @@ def main():
     pp.save(ARTIFACTS_PATH)
 
     lgbm_train = pp.build_lgbm_train(df_full)
-    X_train, y_train = pp.build_patch_train(df_full)
+    X_train, y_train, label_dates = pp.build_patch_train(df_full)
 
     lgb_params = LGBMParams(**LGBM_PARAMS)
     cfg = TrainConfig(**TRAIN_CFG)
@@ -37,7 +37,7 @@ def main():
     if TORCH_OK:
         patch_params = PatchTSTParams(**PATCH_PARAMS)
         pt_tr = PatchTSTTrainer(params=patch_params, L=L, H=H, model_dir=cfg.model_dir)
-        pt_tr.train(X_train, y_train, cfg)
+        pt_tr.train(X_train, y_train, label_dates, cfg)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- track label dates when building PatchTST windows
- split PatchTST training data chronologically with 28-day purge
- pass label dates through training pipeline

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689eede47f688328aeb039d6e22f05db