### PR TITLE
Fix evaluation path to existing test dataset

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -8,7 +8,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 # 데이터 파일 위치(배포시 함께 넣는 상대 경로)
 DATA_DIR = PROJECT_ROOT / "data"
 TRAIN_PATH = str((DATA_DIR / "train.csv").resolve())
-EVAL_PATH  = str((DATA_DIR / "Test_00.csv").resolve())
+EVAL_PATH  = str((DATA_DIR / "TEST_00.csv").resolve())
 
 # 산출물 저장 루트(자동 생성)
 ARTIFACTS_DIR = PROJECT_ROOT / "artifacts"


### PR DESCRIPTION
## Summary
- point EVAL_PATH to `TEST_00.csv` matching dataset name

## Testing
- `python -m pytest`
- `python - <<'PY'
import os
from LGHackerton.config.default import EVAL_PATH
print(EVAL_PATH)
print(os.path.exists(EVAL_PATH))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689f0b9ba9488328a49b126df874a3c9