### PR TITLE
feat: configure validation split and purge

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -41,4 +41,7 @@ TRAIN_CFG = dict(
     priority_weight=3.0,
     use_asinh_target=False,
     model_dir=MODEL_DIR,
+    val_ratio=0.2,
+    min_val_days=28,
+    purge_mode="L",
 )

--- a/LGHackerton/models/base_trainer.py
+++ b/LGHackerton/models/base_trainer.py
@@ -12,6 +12,9 @@ class TrainConfig:
     priority_weight:float=3.0
     use_asinh_target:bool=False
     model_dir:str="./artifacts"
+    val_ratio:float=0.2
+    min_val_days:int=28
+    purge_mode:str="L"
 
 class BaseModel(ABC):
     def __init__(self, model_params: Dict[str, Any], model_dir: str):


### PR DESCRIPTION
## Summary
- add validation split and purge settings to `TrainConfig`
- split PatchTST training data using configurable `val_ratio`, `min_val_days`, and `purge_mode`
- use `purge_mode` in LGBM CV slices and drop fallback logic

## Testing
- `python -m py_compile LGHackerton/models/base_trainer.py LGHackerton/models/patchtst_trainer.py LGHackerton/models/lgbm_trainer.py LGHackerton/config/default.py`
- `python - <<'PY'
import sys
sys.path.append('LGHackerton')
import pandas as pd
from models.lgbm_trainer import LGBMTrainer, LGBMParams
from models.base_trainer import TrainConfig
n=60
df=pd.DataFrame({'label_date': pd.date_range('2024-01-01', periods=n)})
trainer=LGBMTrainer(params=LGBMParams(), features=[], model_dir='.')
cfg=TrainConfig()
folds=trainer._make_cv_slices(df,cfg,'label_date')
print('folds', len(folds))
for tr_mask, va_mask in folds:
    print(tr_mask.sum(), va_mask.sum())
PY`
- `python - <<'PY'
import numpy as np
from LGHackerton.models.base_trainer import TrainConfig
L=28; H=7
cfg=TrainConfig()
n=100
label_dates = np.arange(np.datetime64('2024-01-01'), np.datetime64('2024-01-01')+n)
idx=np.arange(n)
purge_win = L + H if cfg.purge_mode=='L+H' else L
n_val=max(cfg.min_val_days, int(cfg.val_ratio * n))
n_tr=max(1, n - n_val - purge_win)
tr_mask=idx < n_tr
va_mask=idx >= n_tr + purge_win
print('train', tr_mask.sum(), 'val', va_mask.sum())
print(label_dates[tr_mask].max(), label_dates[va_mask].min())
print('assert', label_dates[tr_mask].max() < label_dates[va_mask].min() - np.timedelta64(purge_win,'D'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689f12136e948328aaac2324234f997e