### PR TITLE
feat: include series ids and weighted smape for PatchTST

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -39,6 +39,7 @@ PATCH_PARAMS = dict(
 TRAIN_CFG = dict(
     seed=42, n_folds=3, cv_stride=7,
     priority_weight=3.0,
+    use_weighted_loss=False,
     use_asinh_target=False,
     model_dir=MODEL_DIR,
     val_ratio=0.2,

--- a/LGHackerton/models/base_trainer.py
+++ b/LGHackerton/models/base_trainer.py
@@ -10,6 +10,7 @@ class TrainConfig:
     n_folds:int=3
     cv_stride:int=7
     priority_weight:float=3.0
+    use_weighted_loss:bool=False
     use_asinh_target:bool=False
     model_dir:str="./artifacts"
     val_ratio:float=0.2

--- a/LGHackerton/models/patchtst_trainer.py
+++ b/LGHackerton/models/patchtst_trainer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os, json
 import numpy as np
 from dataclasses import dataclass, asdict
-from typing import Tuple
+from typing import Tuple, Iterable, Optional
 
 try:
     import torch
@@ -15,7 +15,7 @@ except Exception as _e:
     _TORCH_ERR = _e
 
 from models.base_trainer import BaseModel, TrainConfig
-from utils.metrics import smape
+from utils.metrics import smape, weighted_smape_np, PRIORITY_OUTLETS
 
 @dataclass
 class PatchTSTParams:
@@ -32,17 +32,22 @@ class PatchTSTParams:
     patience:int=20
 
 class _SeriesDataset(Dataset):
-    def __init__(self, X: np.ndarray, y: np.ndarray):
+    def __init__(self, X: np.ndarray, y: np.ndarray, series_ids: Optional[Iterable[str]] = None):
         self.X = X.astype(np.float32)
         self.y = y.astype(np.float32)
-    def __len__(self): return self.X.shape[0]
+        if series_ids is None:
+            series_ids = ["" for _ in range(len(X))]
+        self.sids = np.array(list(series_ids))
+    def __len__(self):
+        return self.X.shape[0]
     def __getitem__(self, idx):
         x = self.X[idx]
         mu = x.mean()
         std = x.std()
-        if std == 0: std = 1.0
+        if std == 0:
+            std = 1.0
         x = (x - mu) / std
-        return x, self.y[idx]
+        return x, self.y[idx], self.sids[idx]
 
 if TORCH_OK:
     class PatchTSTBlock(nn.Module):
@@ -84,12 +89,13 @@ class PatchTSTTrainer(BaseModel):
         self.model=None; self.device="cpu"
     def _ensure_torch(self):
         if not TORCH_OK: raise RuntimeError(f"PyTorch not available: {_TORCH_ERR}")
-    def train(self, X_train: np.ndarray, y_train: np.ndarray, label_dates: np.ndarray, cfg: TrainConfig) -> None:
+    def train(self, X_train: np.ndarray, y_train: np.ndarray, series_ids: np.ndarray, label_dates: np.ndarray, cfg: TrainConfig) -> None:
         self._ensure_torch(); import torch
         os.makedirs(self.model_dir, exist_ok=True)
         order = np.argsort(label_dates)
         X_train = X_train[order]
         y_train = y_train[order]
+        series_ids = np.array(series_ids)[order]
         label_dates = label_dates[order]
         n = len(label_dates)
         idx = np.arange(n)
@@ -100,8 +106,8 @@ class PatchTSTTrainer(BaseModel):
         va_mask = idx >= n_tr + purge_win
         assert tr_mask.sum() > 0 and va_mask.sum() > 0
         assert label_dates[tr_mask].max() < label_dates[va_mask].min() - np.timedelta64(purge_win, "D")
-        tr_ds = _SeriesDataset(X_train[tr_mask], y_train[tr_mask])
-        va_ds = _SeriesDataset(X_train[va_mask], y_train[va_mask])
+        tr_ds = _SeriesDataset(X_train[tr_mask], y_train[tr_mask], series_ids[tr_mask])
+        va_ds = _SeriesDataset(X_train[va_mask], y_train[va_mask], series_ids[va_mask])
         tr_loader = DataLoader(tr_ds, batch_size=self.params.batch_size, shuffle=True)
         va_loader = DataLoader(va_ds, batch_size=self.params.batch_size, shuffle=False)
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -113,21 +119,36 @@ class PatchTSTTrainer(BaseModel):
         best=float("inf"); best_state=None; bad=0
         for ep in range(self.params.max_epochs):
             net.train()
-            for xb,yb in tr_loader:
+            for xb,yb,sb in tr_loader:
                 xb, yb = xb.to(self.device), yb.to(self.device)
-                opt.zero_grad(); pred = net(xb); loss = loss_fn(pred,yb); loss.backward(); opt.step()
+                opt.zero_grad()
+                pred = net(xb)
+                if cfg.use_weighted_loss:
+                    outlets = [sid.split("::")[0] for sid in sb]
+                    w = torch.tensor([cfg.priority_weight if o in PRIORITY_OUTLETS else 1.0 for o in outlets], device=self.device).view(-1,1)
+                    loss = (torch.abs(pred - yb) * w).mean()
+                else:
+                    loss = loss_fn(pred, yb)
+                loss.backward(); opt.step()
             # val
-            net.eval(); P=[]; T=[]
+            net.eval(); P=[]; T=[]; S=[]
             with torch.no_grad():
-                for xb,yb in va_loader:
+                for xb,yb,sb in va_loader:
                     xb, yb = xb.to(self.device), yb.to(self.device)
                     out = net(xb)
-                    P.append(out.cpu().numpy()); T.append(yb.cpu().numpy())
+                    P.append(out.cpu().numpy()); T.append(yb.cpu().numpy()); S.extend(sb)
             y_pred = np.clip(np.concatenate(P,0),0,None); y_true = np.concatenate(T,0)
-            val = smape(y_true.ravel(), y_pred.ravel())
-            if val + 1e-8 < best: best=val; best_state=net.state_dict(); bad=0
-            else: bad+=1
-            if bad>=self.params.patience: break
+            outlets = [sid.split("::")[0] for sid in S]
+            eps = 1e-8
+            w_val = weighted_smape_np(y_true.ravel(), y_pred.ravel(), outlets, cfg.priority_weight, eps)
+            s_val = smape(y_true.ravel(), y_pred.ravel(), eps)
+            if w_val + 1e-8 < best:
+                best = w_val; best_state = net.state_dict(); bad = 0
+            else:
+                bad += 1
+            print(f"Epoch {ep}: wSMAPE={w_val:.4f} SMAPE={s_val:.4f}")
+            if bad >= self.params.patience:
+                break
         if best_state is not None: self.model.load_state_dict(best_state)
         self.save(os.path.join(self.model_dir,"patchtst.pt"))
     def predict(self, X_eval: np.ndarray) -> np.ndarray:
@@ -138,7 +159,7 @@ class PatchTSTTrainer(BaseModel):
         loader = torch.utils.data.DataLoader(ds, batch_size=self.params.batch_size, shuffle=False)
         outs=[]
         with torch.no_grad():
-            for xb,_ in loader:
+            for xb,_,_ in loader:
                 xb = xb.to(self.device); outs.append(self.model(xb).cpu().numpy())
         yhat = np.clip(np.concatenate(outs,0),0,None)
         return yhat

--- a/LGHackerton/preprocess_pipeline_v1_1.py
+++ b/LGHackerton/preprocess_pipeline_v1_1.py
@@ -535,9 +535,10 @@ class SampleWindowizer:
 
     def build_patch_train(
             self, df: pd.DataFrame
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Build PatchTST training windows with identifiers."""
         d = df.sort_values([SERIES_COL, DATE_COL]).copy()
-        X_list, Y_list, D_list = [], [], []
+        X_list, Y_list, S_list, D_list = [], [], [], []
         for sid, g in d.groupby(SERIES_COL, sort=False):
             g = g.reset_index(drop=True)
             # windows
@@ -549,18 +550,21 @@ class SampleWindowizer:
                     continue
                 X_list.append(x_window.reshape(self.L, 1))
                 Y_list.append(y_vec)
+                S_list.append(sid)
                 D_list.append(g.loc[t + self.H, DATE_COL])
         if not X_list:
             raise RuntimeError("No PatchTST training windows produced.")
         vprint(f"[PATCH/TRAIN] windows={len(X_list)}")
 
         dates = np.array(D_list, dtype="datetime64[ns]")
+        sids = np.array(S_list, dtype=object)
         order = np.argsort(dates)
         X_arr = np.stack(X_list, axis=0)[order]
         Y_arr = np.stack(Y_list, axis=0)[order]
+        sids = sids[order]
         dates = dates[order]
 
-        return X_arr, Y_arr, dates
+        return X_arr, Y_arr, sids, dates
 
     def build_patch_eval(
             self, df_eval: pd.DataFrame
@@ -679,7 +683,7 @@ class Preprocessor:
     def build_lgbm_eval(self, df_eval_full: pd.DataFrame) -> pd.DataFrame:
         return self.windowizer.build_lgbm_eval(df_eval_full, self.feature_cols)
 
-    def build_patch_train(self, df_full: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def build_patch_train(self, df_full: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         return self.windowizer.build_patch_train(df_full)
 
     def build_patch_eval(self, df_eval_full: pd.DataFrame) -> Tuple[np.ndarray, List[Tuple[str, pd.Timestamp]]]:

--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -27,7 +27,7 @@ def main():
     pp.save(ARTIFACTS_PATH)
 
     lgbm_train = pp.build_lgbm_train(df_full)
-    X_train, y_train, label_dates = pp.build_patch_train(df_full)
+    X_train, y_train, series_ids, label_dates = pp.build_patch_train(df_full)
 
     lgb_params = LGBMParams(**LGBM_PARAMS)
     cfg = TrainConfig(**TRAIN_CFG)
@@ -37,7 +37,7 @@ def main():
     if TORCH_OK:
         patch_params = PatchTSTParams(**PATCH_PARAMS)
         pt_tr = PatchTSTTrainer(params=patch_params, L=L, H=H, model_dir=cfg.model_dir)
-        pt_tr.train(X_train, y_train, label_dates, cfg)
+        pt_tr.train(X_train, y_train, series_ids, label_dates, cfg)
 
 if __name__ == "__main__":
     main()

--- a/LGHackerton/utils/metrics.py
+++ b/LGHackerton/utils/metrics.py
@@ -16,8 +16,11 @@ def smape(y_true: np.ndarray, y_pred: np.ndarray, eps: float = 0.0) -> float:
 
 def weighted_smape_np(y_true: np.ndarray, y_pred: np.ndarray,
                       outlet_names: Optional[Iterable[str]] = None,
-                      priority_weight: float = 3.0) -> float:
+                      priority_weight: float = 3.0,
+                      eps: float = 0.0) -> float:
     denom = (np.abs(y_true) + np.abs(y_pred)) / 2.0
+    if eps > 0:
+        denom = denom + eps
     mask = denom > 0
     sm = np.zeros_like(y_true, dtype=float)
     sm[mask] = np.abs(y_true[mask] - y_pred[mask]) / denom[mask]


### PR DESCRIPTION
## Summary
- return series identifiers and label dates in PatchTST preprocessing
- track series ids in training and evaluate using weighted SMAPE
- add optional outlet-based weighted loss and epsilon-stable wSMAPE

## Testing
- `python -m py_compile LGHackerton/preprocess_pipeline_v1_1.py LGHackerton/train.py LGHackerton/models/patchtst_trainer.py LGHackerton/utils/metrics.py LGHackerton/models/base_trainer.py LGHackerton/config/default.py`

------
https://chatgpt.com/codex/tasks/task_e_689f1ca1e7e88328943bbdbcdb336b2b