### PR TITLE
Add ensemble configuration and import in scripts

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -56,3 +56,8 @@ TRAIN_CFG = dict(
     min_val_samples=28,
     purge_mode="L",
 )
+
+ENSEMBLE_CFG = {
+    "type": "nnls",
+    "fallback": "median",
+}

--- a/LGHackerton/predict.py
+++ b/LGHackerton/predict.py
@@ -12,8 +12,16 @@ except Exception as e:
 
 from models.lgbm_trainer import LGBMTrainer, LGBMParams
 from models.patchtst_trainer import PatchTSTTrainer, PatchTSTParams, TORCH_OK
-from config.default import (EVAL_PATH, ARTIFACTS_PATH, LGBM_EVAL_OUT, PATCH_EVAL_OUT,
-                            LGBM_PARAMS, PATCH_PARAMS, TRAIN_CFG)
+from config.default import (
+    EVAL_PATH,
+    ARTIFACTS_PATH,
+    LGBM_EVAL_OUT,
+    PATCH_EVAL_OUT,
+    LGBM_PARAMS,
+    PATCH_PARAMS,
+    TRAIN_CFG,
+    ENSEMBLE_CFG,
+)
 
 def _read_table(path: str) -> pd.DataFrame:
     if path.lower().endswith(".csv"):

--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -18,6 +18,7 @@ from config.default import (
     PATCH_PARAMS,
     TRAIN_CFG,
     ARTIFACTS_DIR,
+    ENSEMBLE_CFG,
 )
 
 def _read_table(path: str) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- define `ENSEMBLE_CFG` in default configuration
- import `ENSEMBLE_CFG` in training and prediction scripts

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a02b46d0948328a18de7e1d8c5e0d9