### PR TITLE
Support multiple test files in prediction

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -8,7 +8,9 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 # 데이터 파일 위치(배포시 함께 넣는 상대 경로)
 DATA_DIR = PROJECT_ROOT / "data"
 TRAIN_PATH = str((DATA_DIR / "train.csv").resolve())
-EVAL_PATH  = str((DATA_DIR / "TEST_00.csv").resolve())
+TEST_DIR = DATA_DIR
+TEST_GLOB = str((TEST_DIR / "TEST_*.csv").resolve())
+# EVAL_PATH  = str((DATA_DIR / "TEST_00.csv").resolve())
 
 # 산출물 저장 루트(자동 생성)
 ARTIFACTS_DIR = PROJECT_ROOT / "artifacts"

--- a/LGHackerton/predict.py
+++ b/LGHackerton/predict.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 import os
 import random
+import glob
+import re
 import numpy as np
 import pandas as pd
 
@@ -10,10 +12,9 @@ from .models.lgbm_trainer import LGBMTrainer, LGBMParams
 from .models.patchtst_trainer import PatchTSTTrainer, PatchTSTParams, TORCH_OK
 from .utils.ensemble_manager import EnsembleManager
 from .config.default import (
-    EVAL_PATH,
+    TEST_GLOB,
     ARTIFACTS_PATH,
     LGBM_EVAL_OUT,
-    PATCH_EVAL_OUT,
     LGBM_PARAMS,
     PATCH_PARAMS,
     TRAIN_CFG,
@@ -43,45 +44,60 @@ def _read_table(path: str) -> pd.DataFrame:
 
 def main():
     pp = Preprocessor(); pp.load(ARTIFACTS_PATH)
-    df_eval_raw = _read_table(EVAL_PATH)
-    df_eval_full = pp.transform_eval(df_eval_raw)
-
-    lgbm_eval = pp.build_lgbm_eval(df_eval_full)
-    X_eval, sids, _ = pp.build_patch_eval(df_eval_full)
 
     from .models.base_trainer import TrainConfig
     cfg = TrainConfig(**TRAIN_CFG)
     set_seed(cfg.seed)
+
     lgb = LGBMTrainer(params=LGBMParams(**LGBM_PARAMS), features=pp.feature_cols, model_dir=cfg.model_dir)
     lgb.load(os.path.join(cfg.model_dir, "lgbm_models.json"))
-    df_lgb = lgb.predict(lgbm_eval)
 
-    y_patch = None
+    pt = None
     if TORCH_OK and os.path.exists(os.path.join(cfg.model_dir, "patchtst.pt")):
         pt = PatchTSTTrainer(params=PatchTSTParams(**PATCH_PARAMS), L=L, H=H, model_dir=cfg.model_dir)
         pt.load(os.path.join(cfg.model_dir, "patchtst.pt"))
-        sid_idx = np.array([pt.id2idx[sid] for sid in sids])
-        y_patch = pt.predict(X_eval, sid_idx)
-
-    out = df_lgb.copy()
-    if y_patch is not None:
-        reps = np.repeat(sids, H)
-        hs = np.tile(np.arange(1, H + 1), len(sids))
-        dfp = pd.DataFrame({"series_id": reps, "h": hs, "yhat_patch": y_patch.reshape(-1)})
-        out = out.merge(dfp, on=["series_id", "h"], how="left")
-    else:
-        out["yhat_patch"] = np.nan
 
     ens = EnsembleManager()
     ens.load(os.path.join(cfg.model_dir, "ensemble_meta.json"))
-    yhat_ens = ens.predict(
-        df_lgb["yhat_lgbm"].values,
-        out.get("yhat_patch").values,
-    )
-    out["yhat_ens"] = np.where(out["yhat_patch"].notna(), yhat_ens, df_lgb["yhat_lgbm"].values)
+
+    all_outputs = []
+
+    for path in sorted(glob.glob(TEST_GLOB)):
+        df_eval_raw = _read_table(path)
+        df_eval_full = pp.transform_eval(df_eval_raw)
+
+        lgbm_eval = pp.build_lgbm_eval(df_eval_full)
+        X_eval, sids, _ = pp.build_patch_eval(df_eval_full)
+
+        df_lgb = lgb.predict(lgbm_eval)
+
+        y_patch = None
+        if pt is not None:
+            sid_idx = np.array([pt.id2idx[sid] for sid in sids])
+            y_patch = pt.predict(X_eval, sid_idx)
+
+        out = df_lgb.copy()
+        if y_patch is not None:
+            reps = np.repeat(sids, H)
+            hs = np.tile(np.arange(1, H + 1), len(sids))
+            dfp = pd.DataFrame({"series_id": reps, "h": hs, "yhat_patch": y_patch.reshape(-1)})
+            out = out.merge(dfp, on=["series_id", "h"], how="left")
+        else:
+            out["yhat_patch"] = np.nan
+
+        yhat_ens = ens.predict(
+            df_lgb["yhat_lgbm"].values,
+            out.get("yhat_patch").values,
+        )
+        out["yhat_ens"] = np.where(out["yhat_patch"].notna(), yhat_ens, df_lgb["yhat_lgbm"].values)
+
+        prefix = re.search(r"(TEST_\d+)", os.path.basename(path)).group(1)
+        out["test_id"] = prefix
+        out["date"] = out["h"].map(lambda h: f"{prefix}+{h}일")
+        all_outputs.append(out)
 
     os.makedirs(os.path.dirname(LGBM_EVAL_OUT), exist_ok=True)
-    out.to_csv(LGBM_EVAL_OUT, index=False, encoding="utf-8-sig")
+    pd.concat(all_outputs, ignore_index=True).to_csv(LGBM_EVAL_OUT, index=False, encoding="utf-8-sig")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Add TEST_DIR and TEST_GLOB config for scanning evaluation inputs
- Refactor predictor to loop over all TEST_*.csv files and tag outputs with test IDs

## Testing
- `python -m LGHackerton.predict` *(fails: No such file or directory: '.../lgbm_models.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a03c8b71908328a2b24440eae40cbc