### PR TITLE
Add pyproject for installable package with console scripts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.md
+recursive-include LGHackerton/data *.csv
+recursive-include LGHackerton/config *.py
+recursive-include LGHackerton/artifacts *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "LGHackerton"
+version = "0.1.0"
+description = "Demand forecasting pipeline for D&O Gonjiam"
+authors = [{name="Your Name", email="you@example.com"}]
+dependencies = [
+    "numpy>=1.23",
+    "pandas>=1.5",
+    "lightgbm>=3.3",
+    "torch>=1.13; extra == 'torch'",      # optional GPU/NN support
+    "holidayskr>=0.2; extra == 'kr-holidays'",  # optional holiday features
+]
+[project.optional-dependencies]
+full = ["torch>=1.13", "holidayskr>=0.2"]
+
+[project.scripts]
+bellman-predict = "LGHackerton.predict:main"
+bellman-train   = "LGHackerton.train:main"


### PR DESCRIPTION
## Summary
- add `pyproject.toml` configuring build system, dependencies, optional extras, and console scripts for `bellman-predict` and `bellman-train`
- include data, config, and artifacts in source distribution via `MANIFEST.in`

## Testing
- `pip install -e .`
- `bellman-predict` *(fails: NameError: name 'Dataset' is not defined)*
- `python -m LGHackerton.predict` *(fails: NameError: name 'Dataset' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a05ac24fe48328819aa7dd5b93e89b