### PR TITLE
refactor: remove relative imports

### DIFF
--- a/LGHackerton/models/lgbm_trainer.py
+++ b/LGHackerton/models/lgbm_trainer.py
@@ -7,9 +7,9 @@ from dataclasses import dataclass, asdict
 from typing import Dict, List, Tuple, Any
 
 import lightgbm as lgb
-from .base_trainer import BaseModel, TrainConfig
-from ..utils.metrics import lgbm_weighted_smape
-from ..preprocess import L, H
+from LGHackerton.models.base_trainer import BaseModel, TrainConfig
+from LGHackerton.utils.metrics import lgbm_weighted_smape
+from LGHackerton.preprocess import L, H
 PRIORITY_OUTLETS = {"담하", "미라시아"}
 
 @dataclass

--- a/LGHackerton/models/patchtst_trainer.py
+++ b/LGHackerton/models/patchtst_trainer.py
@@ -14,8 +14,8 @@ except Exception as _e:
     TORCH_OK = False
     _TORCH_ERR = _e
 
-from .base_trainer import BaseModel, TrainConfig
-from ..utils.metrics import smape, weighted_smape_np, PRIORITY_OUTLETS
+from LGHackerton.models.base_trainer import BaseModel, TrainConfig
+from LGHackerton.utils.metrics import smape, weighted_smape_np, PRIORITY_OUTLETS
 
 @dataclass
 class PatchTSTParams:

--- a/LGHackerton/predict.py
+++ b/LGHackerton/predict.py
@@ -7,11 +7,11 @@ import re
 import numpy as np
 import pandas as pd
 
-from .preprocess import Preprocessor, L, H
-from .models.lgbm_trainer import LGBMTrainer, LGBMParams
-from .models.patchtst_trainer import PatchTSTTrainer, PatchTSTParams, TORCH_OK
-from .utils.ensemble_manager import EnsembleManager
-from .config.default import (
+from LGHackerton.preprocess import Preprocessor, L, H
+from LGHackerton.models.lgbm_trainer import LGBMTrainer, LGBMParams
+from LGHackerton.models.patchtst_trainer import PatchTSTTrainer, PatchTSTParams, TORCH_OK
+from LGHackerton.utils.ensemble_manager import EnsembleManager
+from LGHackerton.config.default import (
     TEST_GLOB,
     ARTIFACTS_PATH,
     LGBM_EVAL_OUT,
@@ -59,7 +59,7 @@ def convert_to_submission(pred_df: pd.DataFrame, sample_path: str) -> pd.DataFra
 def main():
     pp = Preprocessor(); pp.load(ARTIFACTS_PATH)
 
-    from .models.base_trainer import TrainConfig
+    from LGHackerton.models.base_trainer import TrainConfig
     cfg = TrainConfig(**TRAIN_CFG)
     set_seed(cfg.seed)
 

--- a/LGHackerton/preprocess/__init__.py
+++ b/LGHackerton/preprocess/__init__.py
@@ -1,4 +1,4 @@
-from .preprocess_pipeline_v1_1 import (
+from LGHackerton.preprocess.preprocess_pipeline_v1_1 import (
     Preprocessor,
     DATE_COL,
     SERIES_COL,

--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -5,11 +5,11 @@ import random
 import numpy as np
 import pandas as pd
 
-from .preprocess import Preprocessor, DATE_COL, SERIES_COL, SALES_COL, L, H
-from .models.base_trainer import TrainConfig
-from .models.lgbm_trainer import LGBMParams, LGBMTrainer
-from .models.patchtst_trainer import PatchTSTParams, PatchTSTTrainer, TORCH_OK
-from .config.default import (
+from LGHackerton.preprocess import Preprocessor, DATE_COL, SERIES_COL, SALES_COL, L, H
+from LGHackerton.models.base_trainer import TrainConfig
+from LGHackerton.models.lgbm_trainer import LGBMParams, LGBMTrainer
+from LGHackerton.models.patchtst_trainer import PatchTSTParams, PatchTSTTrainer, TORCH_OK
+from LGHackerton.config.default import (
     TRAIN_PATH,
     ARTIFACTS_PATH,
     LGBM_PARAMS,


### PR DESCRIPTION
## Summary
- replace all relative imports with absolute `LGHackerton` package paths
- expose preprocessing pipeline through package __init__

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a05bc644808328ade23994154bdebc