### PR TITLE
feat: centralize seeding utility

### DIFF
--- a/LGHackerton/predict.py
+++ b/LGHackerton/predict.py
@@ -1,7 +1,6 @@
 
 from __future__ import annotations
 import os
-import random
 import glob
 import re
 import numpy as np
@@ -22,20 +21,7 @@ from LGHackerton.config.default import (
     TRAIN_CFG,
     ENSEMBLE_CFG,
 )
-
-
-def set_seed(seed: int) -> None:
-    random.seed(seed)
-    np.random.seed(seed)
-    try:
-        import torch
-
-        torch.manual_seed(seed)
-        torch.cuda.manual_seed_all(seed)
-        torch.backends.cudnn.deterministic = True
-        torch.backends.cudnn.benchmark = False
-    except Exception:
-        pass
+from LGHackerton.utils.seed import set_seed
 
 def _read_table(path: str) -> pd.DataFrame:
     if path.lower().endswith(".csv"):

--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -1,8 +1,6 @@
 
 from __future__ import annotations
 import os
-import random
-import numpy as np
 import pandas as pd
 
 from LGHackerton.preprocess import Preprocessor, DATE_COL, SERIES_COL, SALES_COL, L, H
@@ -18,20 +16,7 @@ from LGHackerton.config.default import (
     ARTIFACTS_DIR,
     ENSEMBLE_CFG,
 )
-
-
-def set_seed(seed: int) -> None:
-    random.seed(seed)
-    np.random.seed(seed)
-    try:
-        import torch
-
-        torch.manual_seed(seed)
-        torch.cuda.manual_seed_all(seed)
-        torch.backends.cudnn.deterministic = True
-        torch.backends.cudnn.benchmark = False
-    except Exception:
-        pass
+from LGHackerton.utils.seed import set_seed
 
 def _read_table(path: str) -> pd.DataFrame:
     if path.lower().endswith(".csv"):

--- a/LGHackerton/utils/seed.py
+++ b/LGHackerton/utils/seed.py
@@ -1,0 +1,17 @@
+import random
+import numpy as np
+
+try:
+    import torch
+except Exception:
+    torch = None
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    if torch is not None:
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False


### PR DESCRIPTION
## Summary
- add reusable `set_seed` helper under `utils`
- refactor `train.py` and `predict.py` to use shared seeding utility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06d15f71c83289bdfcf6a83a1ff2c