### PR TITLE
Add explicit OOF output paths

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -26,6 +26,8 @@ SUBMISSION_OUT  = str((ARTIFACTS_DIR / "submission.csv").resolve())
 PATCH_EVAL_OUT  = str((ARTIFACTS_DIR / "patch_eval").resolve())
 # PatchTST 예측 결과 저장 경로
 PATCH_PRED_OUT  = str((ARTIFACTS_DIR / "eval_patch.csv").resolve())
+OOF_LGBM_OUT  = str((ARTIFACTS_DIR / "oof_lgbm.csv").resolve())
+OOF_PATCH_OUT = str((ARTIFACTS_DIR / "oof_patch.csv").resolve())
 
 # 하이퍼파라미터(필요 시 그대로 유지)
 LGBM_PARAMS = dict(

--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -15,6 +15,8 @@ from LGHackerton.config.default import (
     TRAIN_CFG,
     ARTIFACTS_DIR,
     ENSEMBLE_CFG,
+    OOF_LGBM_OUT,
+    OOF_PATCH_OUT,
 )
 from LGHackerton.utils.seed import set_seed
 
@@ -39,13 +41,13 @@ def main():
     set_seed(cfg.seed)
     lgb_tr = LGBMTrainer(params=lgb_params, features=pp.feature_cols, model_dir=cfg.model_dir)
     lgb_tr.train(lgbm_train, cfg)
-    lgb_tr.get_oof().to_csv(ARTIFACTS_DIR / "oof_lgbm.csv", index=False)
+    lgb_tr.get_oof().to_csv(OOF_LGBM_OUT, index=False)
 
     if TORCH_OK:
         patch_params = PatchTSTParams(**PATCH_PARAMS)
         pt_tr = PatchTSTTrainer(params=patch_params, L=L, H=H, model_dir=cfg.model_dir)
         pt_tr.train(X_train, y_train, series_ids, label_dates, cfg)
-        pt_tr.get_oof().to_csv(ARTIFACTS_DIR / "oof_patch.csv", index=False)
+        pt_tr.get_oof().to_csv(OOF_PATCH_OUT, index=False)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- define `OOF_LGBM_OUT` and `OOF_PATCH_OUT` in default config
- use the new OOF output paths in training

## Testing
- `python -m py_compile LGHackerton/config/default.py LGHackerton/train.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06ddf4b6483288cc28e456b25e053