### PR TITLE
Add device selection for GPU/MPS/CPU and integrate with trainers

### DIFF
--- a/LGHackerton/models/lgbm_trainer.py
+++ b/LGHackerton/models/lgbm_trainer.py
@@ -28,10 +28,11 @@ class LGBMParams:
     early_stopping_rounds: int = 200
 
 class LGBMTrainer(BaseModel):
-    def __init__(self, params: LGBMParams, features: List[str], model_dir: str):
+    def __init__(self, params: LGBMParams, features: List[str], model_dir: str, device: str):
         super().__init__(model_params=asdict(params), model_dir=model_dir)
         self.params = params
         self.features = features
+        self.device = device  # 'cpu', 'cuda', or 'mps'
         # for each horizon keep separate lists for regressor and classifier boosters
         self.models: Dict[int, Dict[str, List[lgb.Booster]]] = {
             h: {"reg": [], "clf": []} for h in range(1, 8)
@@ -113,6 +114,7 @@ class LGBMTrainer(BaseModel):
                         reg_alpha=self.params.reg_alpha,
                         reg_lambda=self.params.reg_lambda,
                         metric="binary_logloss",
+                        device_type="gpu" if self.device == "cuda" else "cpu",
                     )
                     callbacks = []
                     if self.params.early_stopping_rounds and self.params.early_stopping_rounds > 0:
@@ -150,6 +152,7 @@ class LGBMTrainer(BaseModel):
                         reg_alpha=self.params.reg_alpha,
                         reg_lambda=self.params.reg_lambda,
                         metric=None,
+                        device_type="gpu" if self.device == "cuda" else "cpu",
                     )
                     if obj == "tweedie":
                         reg_params["tweedie_variance_power"] = self.params.tweedie_variance_power
@@ -199,6 +202,7 @@ class LGBMTrainer(BaseModel):
                         reg_alpha=self.params.reg_alpha,
                         reg_lambda=self.params.reg_lambda,
                         metric=None,
+                        device_type="gpu" if self.device == "cuda" else "cpu",
                     )
                     if obj == "tweedie":
                         lgb_params["tweedie_variance_power"] = self.params.tweedie_variance_power

--- a/LGHackerton/utils/device.py
+++ b/LGHackerton/utils/device.py
@@ -1,0 +1,24 @@
+import torch
+
+
+def select_device() -> str:
+    """Interactively select computing device.
+
+    Returns 'cpu', 'cuda', or 'mps'.
+    """
+    while True:
+        choice = input("Select compute environment (macOS/gpu/cpu): ").strip().lower()
+        if choice == "macos":
+            if torch.backends.mps.is_available():
+                return "mps"
+            else:
+                print("MPS not available. Please choose another option.")
+        elif choice in ("gpu", "cuda"):
+            if torch.cuda.is_available():
+                return "cuda"
+            else:
+                print("CUDA GPU not available. Please choose another option.")
+        elif choice == "cpu":
+            return "cpu"
+        else:
+            print("Invalid option. Choose from macOS/gpu/cpu.")


### PR DESCRIPTION
## Summary
- add `select_device` utility to choose CPU, CUDA, or MPS
- pass device option to LGBM and PatchTST trainers and move tensors accordingly
- update training and prediction scripts to use the selected device

## Testing
- `python -m py_compile LGHackerton/utils/device.py LGHackerton/models/lgbm_trainer.py LGHackerton/models/patchtst_trainer.py LGHackerton/train.py LGHackerton/predict.py`


------
https://chatgpt.com/codex/tasks/task_e_68a072bcf3ec83288d1b069344e5c4de