### PR TITLE
Remove redundant return in build_lgbm_eval

### DIFF
--- a/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
+++ b/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
@@ -530,9 +530,6 @@ class SampleWindowizer:
         vprint(f"[LGBM/EVAL] rows={len(_out)}  feats={len(feature_cols)}")
         return _out
 
-
-        return pd.DataFrame(out_rows).reset_index(drop=True)
-
     def build_patch_train(
             self, df: pd.DataFrame
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:


### PR DESCRIPTION
## Summary
- Remove extraneous return statement in `build_lgbm_eval` of preprocessing pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a07bbe878c8328b9d33fa9a1610752