### PR TITLE
refactor: move artifact directory creation

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -13,9 +13,8 @@ TEST_GLOB = str((TEST_DIR / "TEST_*.csv").resolve())
 # EVAL_PATH  = str((DATA_DIR / "TEST_00.csv").resolve())
 SAMPLE_SUB_PATH = str((DATA_DIR / "sample_submission.csv").resolve())
 
-# 산출물 저장 루트(자동 생성)
+# 산출물 저장 루트
 ARTIFACTS_DIR = PROJECT_ROOT / "artifacts"
-ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
 
 # 모델/피처 산출물 경로
 MODEL_DIR       = str((ARTIFACTS_DIR / "models").resolve())

--- a/LGHackerton/predict.py
+++ b/LGHackerton/predict.py
@@ -21,6 +21,7 @@ from LGHackerton.config.default import (
     PATCH_PARAMS,
     TRAIN_CFG,
     ENSEMBLE_CFG,
+    ARTIFACTS_DIR,
 )
 from LGHackerton.utils.seed import set_seed
 
@@ -44,12 +45,14 @@ def convert_to_submission(pred_df: pd.DataFrame, sample_path: str) -> pd.DataFra
     return out_df
 
 def main():
+    os.makedirs(ARTIFACTS_DIR, exist_ok=True)
     device = select_device()
 
     pp = Preprocessor(); pp.load(ARTIFACTS_PATH)
 
     from LGHackerton.models.base_trainer import TrainConfig
     cfg = TrainConfig(**TRAIN_CFG)
+    os.makedirs(cfg.model_dir, exist_ok=True)
     set_seed(cfg.seed)
 
     lgb = LGBMTrainer(params=LGBMParams(**LGBM_PARAMS), features=pp.feature_cols, model_dir=cfg.model_dir, device=device)

--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -29,6 +29,7 @@ def _read_table(path: str) -> pd.DataFrame:
     raise ValueError("Unsupported file type. Use .csv or .xlsx")
 
 def main():
+    os.makedirs(ARTIFACTS_DIR, exist_ok=True)
     device = select_device()  # ask user for compute environment
 
     df_train_raw = _read_table(TRAIN_PATH)
@@ -41,6 +42,7 @@ def main():
 
     lgb_params = LGBMParams(**LGBM_PARAMS)
     cfg = TrainConfig(**TRAIN_CFG)
+    os.makedirs(cfg.model_dir, exist_ok=True)
     set_seed(cfg.seed)
     lgb_tr = LGBMTrainer(params=lgb_params, features=pp.feature_cols, model_dir=cfg.model_dir, device=device)
     lgb_tr.train(lgbm_train, cfg)


### PR DESCRIPTION
## Summary
- stop creating artifact directory during config import
- create artifact and model directories at startup in train.py and predict.py

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07d7aa2a88328ade0406fab7bb402