### PR TITLE
Handle BOM and normalize series IDs for submission

### DIFF
--- a/LGHackerton/predict.py
+++ b/LGHackerton/predict.py
@@ -27,7 +27,7 @@ from LGHackerton.utils.seed import set_seed
 
 def _read_table(path: str) -> pd.DataFrame:
     if path.lower().endswith(".csv"):
-        return pd.read_csv(path)
+        return pd.read_csv(path, encoding="utf-8-sig")
     if path.lower().endswith((".xls", ".xlsx")):
         return pd.read_excel(path)
     raise ValueError("Unsupported file type. Use .csv or .xlsx")
@@ -35,6 +35,11 @@ def _read_table(path: str) -> pd.DataFrame:
 
 def convert_to_submission(pred_df: pd.DataFrame, sample_path: str) -> pd.DataFrame:
     sample_df = _read_table(sample_path)
+    sample_df.columns = sample_df.columns.str.strip().str.lstrip("\ufeff")
+
+    pred_df = pred_df.copy()
+    pred_df["series_id"] = pred_df["series_id"].str.replace("::", "_", n=1)
+
     wide = pred_df.pivot(index="date", columns="series_id", values="yhat_ens")
     wide = wide.reindex(sample_df.iloc[:, 0]).reindex(columns=sample_df.columns[1:], fill_value=0.0)
 


### PR DESCRIPTION
## Summary
- Ensure `_read_table` reads CSV files with `utf-8-sig` encoding to strip BOM
- Clean sample columns and normalize `series_id` values in `convert_to_submission`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0a8d9e7b48328a69eba977f00841e