### PR TITLE
Add residual diagnostics for model training

### DIFF
--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -12,6 +12,13 @@ from LGHackerton.models.base_trainer import TrainConfig
 from LGHackerton.models.lgbm_trainer import LGBMParams, LGBMTrainer
 from LGHackerton.models.patchtst_trainer import PatchTSTParams, PatchTSTTrainer, TORCH_OK
 from LGHackerton.utils.device import select_device
+from LGHackerton.utils.diagnostics import (
+    compute_acf,
+    compute_pacf,
+    ljung_box_test,
+    white_test,
+    plot_residuals,
+)
 from LGHackerton.config.default import (
     TRAIN_PATH,
     ARTIFACTS_PATH,
@@ -99,7 +106,27 @@ def main(show_progress: bool | None = None):
     set_seed(cfg.seed)
     lgb_tr = LGBMTrainer(params=lgb_params, features=pp.feature_cols, model_dir=cfg.model_dir, device=device)
     lgb_tr.train(lgbm_train, cfg)
-    lgb_tr.get_oof().to_csv(OOF_LGBM_OUT, index=False)
+    oof_lgbm = lgb_tr.get_oof()
+    oof_lgbm.to_csv(OOF_LGBM_OUT, index=False)
+
+    # diagnostics for LGBM
+    try:
+        res = oof_lgbm["y"] - oof_lgbm["yhat"]
+        diag_dir = ARTIFACTS_DIR / "diagnostics" / "lgbm" / "oof"
+        diag_dir.mkdir(parents=True, exist_ok=True)
+        acf_df = compute_acf(res)
+        pacf_df = compute_pacf(res)
+        lb_df = ljung_box_test(res, lags=[10, 20, 30])
+        wt_df = white_test(res)
+        acf_df.to_csv(diag_dir / "acf.csv", index=False)
+        pacf_df.to_csv(diag_dir / "pacf.csv", index=False)
+        lb_df.to_csv(diag_dir / "ljung_box.csv", index=False)
+        wt_df.to_csv(diag_dir / "white_test.csv", index=False)
+        plot_residuals(res, diag_dir)
+        logging.info("LGBM Ljung-Box p-values: %s", lb_df["pvalue"].tolist())
+        logging.info("LGBM White test p-value: %s", wt_df["lm_pvalue"].iloc[0])
+    except Exception as e:  # pragma: no cover - best effort
+        logging.warning("LGBM diagnostics failed: %s", e)
 
     if TORCH_OK and not args.skip_tune:
         patch_file = Path(OPTUNA_DIR) / "patchtst_best.json"
@@ -111,7 +138,27 @@ def main(show_progress: bool | None = None):
         patch_params = PatchTSTParams(**patch_params_dict)
         pt_tr = PatchTSTTrainer(params=patch_params, L=L, H=H, model_dir=cfg.model_dir, device=device)
         pt_tr.train(X_train, y_train, series_ids, label_dates, cfg)
-        pt_tr.get_oof().to_csv(OOF_PATCH_OUT, index=False)
+        oof_patch = pt_tr.get_oof()
+        oof_patch.to_csv(OOF_PATCH_OUT, index=False)
+
+        # diagnostics for PatchTST
+        try:
+            res_p = oof_patch["y"] - oof_patch["yhat"]
+            diag_dir = ARTIFACTS_DIR / "diagnostics" / "patchtst" / "oof"
+            diag_dir.mkdir(parents=True, exist_ok=True)
+            acf_df = compute_acf(res_p)
+            pacf_df = compute_pacf(res_p)
+            lb_df = ljung_box_test(res_p, lags=[10, 20, 30])
+            wt_df = white_test(res_p)
+            acf_df.to_csv(diag_dir / "acf.csv", index=False)
+            pacf_df.to_csv(diag_dir / "pacf.csv", index=False)
+            lb_df.to_csv(diag_dir / "ljung_box.csv", index=False)
+            wt_df.to_csv(diag_dir / "white_test.csv", index=False)
+            plot_residuals(res_p, diag_dir)
+            logging.info("PatchTST Ljung-Box p-values: %s", lb_df["pvalue"].tolist())
+            logging.info("PatchTST White test p-value: %s", wt_df["lm_pvalue"].iloc[0])
+        except Exception as e:  # pragma: no cover - best effort
+            logging.warning("PatchTST diagnostics failed: %s", e)
 
 if __name__ == "__main__":
     main()

--- a/LGHackerton/utils/diagnostics.py
+++ b/LGHackerton/utils/diagnostics.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import pandas as pd
+
+
+def _validate_series(residuals: pd.Series, min_len: int) -> pd.Series:
+    """Validate residual series for diagnostics functions."""
+    if not isinstance(residuals, pd.Series):
+        raise TypeError("residuals must be a pandas Series")
+    res = residuals.dropna()
+    if res.empty:
+        raise ValueError("residual series is empty")
+    if len(res) <= min_len:
+        raise ValueError(f"residual series length must exceed {min_len}")
+    return res
+
+
+def compute_acf(residuals: pd.Series, nlags: int = 40) -> pd.DataFrame:
+    """Autocorrelation function with Q-statistics and p-values."""
+    res = _validate_series(residuals, nlags)
+    try:
+        from statsmodels.tsa.stattools import acf
+    except Exception as e:  # pragma: no cover - dependency check
+        raise ImportError("statsmodels is required for compute_acf") from e
+    acf_vals, confint, qstat, pvals = acf(res, nlags=nlags, qstat=True, alpha=0.05)
+    lags = np.arange(len(acf_vals))
+    qstat = np.insert(qstat, 0, np.nan)
+    pvals = np.insert(pvals, 0, np.nan)
+    return pd.DataFrame(
+        {
+            "lag": lags,
+            "acf": acf_vals,
+            "qstat": qstat,
+            "pvalue": pvals,
+            "confint_lower": confint[:, 0],
+            "confint_upper": confint[:, 1],
+        }
+    )
+
+
+def compute_pacf(residuals: pd.Series, nlags: int = 40) -> pd.DataFrame:
+    """Partial autocorrelation function with approximate p-values."""
+    res = _validate_series(residuals, nlags)
+    try:
+        from statsmodels.tsa.stattools import pacf
+    except Exception as e:  # pragma: no cover - dependency check
+        raise ImportError("statsmodels is required for compute_pacf") from e
+    try:
+        from scipy import stats
+    except Exception as e:  # pragma: no cover - dependency check
+        raise ImportError("scipy is required for compute_pacf") from e
+    pacf_vals, confint = pacf(res, nlags=nlags, alpha=0.05, method="ywmle")
+    se = (confint[:, 1] - confint[:, 0]) / (2 * 1.96)
+    pvals = 2 * (1 - stats.norm.cdf(np.abs(pacf_vals) / se))
+    lags = np.arange(len(pacf_vals))
+    return pd.DataFrame(
+        {
+            "lag": lags,
+            "pacf": pacf_vals,
+            "pvalue": pvals,
+            "confint_lower": confint[:, 0],
+            "confint_upper": confint[:, 1],
+        }
+    )
+
+
+def ljung_box_test(residuals: pd.Series, lags: List[int]) -> pd.DataFrame:
+    """Ljung-Box test for autocorrelation."""
+    if not lags:
+        raise ValueError("lags must be a non-empty list")
+    max_lag = max(lags)
+    res = _validate_series(residuals, max_lag)
+    try:
+        from statsmodels.stats.diagnostic import acorr_ljungbox
+    except Exception as e:  # pragma: no cover - dependency check
+        raise ImportError("statsmodels is required for ljung_box_test") from e
+    lb = acorr_ljungbox(res, lags=lags, return_df=True)
+    lb = lb.rename(columns={"lb_stat": "stat", "lb_pvalue": "pvalue"})
+    lb.insert(0, "lag", lags)
+    return lb
+
+
+def white_test(residuals: pd.Series, exog: pd.DataFrame | None = None) -> pd.DataFrame:
+    """White's test for heteroskedasticity."""
+    res = _validate_series(residuals, 1)
+    try:
+        from statsmodels.stats.diagnostic import het_white
+        import statsmodels.api as sm
+    except Exception as e:  # pragma: no cover - dependency check
+        raise ImportError("statsmodels is required for white_test") from e
+    if exog is None:
+        exog = pd.DataFrame(
+            {"const": np.ones(len(res)), "trend": np.arange(len(res))},
+            index=res.index,
+        )
+    else:
+        if not isinstance(exog, pd.DataFrame):
+            raise TypeError("exog must be a pandas DataFrame or None")
+        if len(exog) != len(res):
+            raise ValueError("exog must have same length as residuals")
+        exog = exog.reindex(res.index)
+        exog = sm.add_constant(exog, has_constant="add")
+    lm_stat, lm_pvalue, f_stat, f_pvalue = het_white(res, exog)
+    return pd.DataFrame(
+        {
+            "lm_stat": [lm_stat],
+            "lm_pvalue": [lm_pvalue],
+            "f_stat": [f_stat],
+            "f_pvalue": [f_pvalue],
+        }
+    )
+
+
+def plot_residuals(residuals: pd.Series, out_dir: Path) -> None:
+    """Plot residual diagnostics and save to directory."""
+    res = _validate_series(residuals, 1)
+    try:
+        import matplotlib.pyplot as plt
+        from statsmodels.graphics.tsaplots import plot_acf, plot_pacf
+    except Exception as e:  # pragma: no cover - dependency check
+        raise ImportError(
+            "matplotlib and statsmodels are required for plot_residuals"
+        ) from e
+    os.makedirs(out_dir, exist_ok=True)
+    # time series plot
+    fig, ax = plt.subplots()
+    res.plot(ax=ax)
+    ax.set_title("Residuals")
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Residual")
+    fig.savefig(Path(out_dir) / "residuals.png", bbox_inches="tight")
+    plt.close(fig)
+    # histogram
+    fig, ax = plt.subplots()
+    ax.hist(res, bins=20, edgecolor="black")
+    ax.set_title("Residual Histogram")
+    fig.savefig(Path(out_dir) / "histogram.png", bbox_inches="tight")
+    plt.close(fig)
+    # ACF plot
+    nlags = min(40, len(res) - 1)
+    fig = plot_acf(res, lags=nlags)
+    fig.savefig(Path(out_dir) / "acf.png", bbox_inches="tight")
+    plt.close(fig)
+    # PACF plot
+    fig = plot_pacf(res, lags=nlags)
+    fig.savefig(Path(out_dir) / "pacf.png", bbox_inches="tight")
+    plt.close(fig)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+numpy
+pandas
+lightgbm
+torch
+holidayskr
+optuna
+statsmodels
+matplotlib


### PR DESCRIPTION
## Summary
- add diagnostics utilities (ACF, PACF, Ljung-Box, White test, residual plots)
- integrate residual diagnostics into training pipeline for LGBM and PatchTST models
- declare statsmodels and matplotlib dependencies

## Testing
- `pip install statsmodels matplotlib`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1c30e98cc83288570ffd8cc293ac3