### PR TITLE
Add PatchTST grid search and RevIN normalization support

### DIFF
--- a/LGHackerton/tune.py
+++ b/LGHackerton/tune.py
@@ -14,11 +14,17 @@ import logging
 import os
 from pathlib import Path
 from typing import Any, List, Tuple
+import sys
+
+import itertools
 
 import numpy as np
 import optuna
 import pandas as pd
 import lightgbm as lgb
+import yaml
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 try:  # torch is optional; used only for GPU cache clearing
     import torch
@@ -309,10 +315,99 @@ def tune_patchtst(X, y, series_ids, label_dates, cfg):
     return study
 
 
+def run_patchtst_grid_search(cfg_path: str | Path) -> None:
+    """Run a simple grid search over PatchTST hyperparameters."""
+
+    from LGHackerton.models.patchtst_trainer import PatchTSTParams, PatchTSTTrainer, TORCH_OK
+    from LGHackerton.preprocess import H
+    from LGHackerton.preprocess.preprocess_pipeline_v1_1 import SampleWindowizer
+
+    if not TORCH_OK:
+        raise RuntimeError("PyTorch not available for PatchTST")
+
+    with open(cfg_path, "r", encoding="utf-8") as f:
+        cfg_dict = yaml.safe_load(f)
+    cfg = TrainConfig(**cfg_dict)
+
+    df_raw = pd.read_csv(TRAIN_PATH)
+    pp = Preprocessor(show_progress=False)
+    df_full = pp.fit_transform_train(df_raw)
+
+    input_lens = [96, 168, 336]
+    patch_lens = [16, 24, 32]
+    lrs = [1e-4, 5e-4, 1e-3]
+    scalers = ["per_series", "revin"]
+
+    device = "cuda" if torch and torch.cuda.is_available() else "cpu"
+    results: List[dict[str, Any]] = []
+
+    for inp, patch, lr, scaler in itertools.product(input_lens, patch_lens, lrs, scalers):
+        if inp % patch != 0:
+            continue
+        try:
+            set_seed(42)
+            pp.windowizer = SampleWindowizer(lookback=inp, horizon=H)
+            X, y, series_ids, label_dates = pp.build_patch_train(df_full)
+            params = PatchTSTParams(patch_len=patch, stride=patch, lr=lr, scaler=scaler)
+            trainer = PatchTSTTrainer(params=params, L=inp, H=H, model_dir=cfg.model_dir, device=device)
+            trainer.train(X, y, series_ids, label_dates, cfg)
+            oof = trainer.get_oof()
+            outlets = oof["series_id"].str.split("::").str[0].values
+            val_w = weighted_smape_np(
+                oof["y"].values,
+                oof["yhat"].values,
+                outlets,
+                priority_weight=getattr(cfg, "priority_weight", 1.0),
+            )
+            val_mae = float(np.mean(np.abs(oof["y"].values - oof["yhat"].values)))
+            results.append(
+                {
+                    "input_len": inp,
+                    "patch_len": patch,
+                    "lr": lr,
+                    "scaler": scaler,
+                    "val_wsmape": float(val_w),
+                    "val_mae": val_mae,
+                }
+            )
+            logger.info(
+                "inp=%s patch=%s lr=%s scaler=%s wSMAPE=%.4f MAE=%.4f",
+                inp,
+                patch,
+                lr,
+                scaler,
+                val_w,
+                val_mae,
+            )
+        except Exception as e:  # pragma: no cover - robustness
+            logger.exception(
+                "Grid combo failed for input_len=%s patch_len=%s lr=%s scaler=%s",
+                inp,
+                patch,
+                lr,
+                scaler,
+            )
+            results.append(
+                {
+                    "input_len": inp,
+                    "patch_len": patch,
+                    "lr": lr,
+                    "scaler": scaler,
+                    "error": str(e),
+                }
+            )
+            continue
+
+    os.makedirs("artifacts", exist_ok=True)
+    pd.DataFrame(results).to_csv(Path("artifacts") / "patchtst_search.csv", index=False)
+
+
 def main() -> None:  # pragma: no cover - CLI entry point
     """Entry point for command-line usage."""
 
     parser = argparse.ArgumentParser(description="Hyperparameter tuning utilities")
+    parser.add_argument("--task", type=str, default=None, help="special task to run")
+    parser.add_argument("--config", type=str, default="configs/baseline.yaml", help="config path")
     parser.add_argument("--lgbm", action="store_true", help="tune LightGBM hyperparameters")
     parser.add_argument("--patch", action="store_true", help="tune PatchTST hyperparameters")
     parser.add_argument("--n-trials", type=int, default=30, help="number of Optuna trials")
@@ -321,6 +416,10 @@ def main() -> None:  # pragma: no cover - CLI entry point
     )
     parser.add_argument("--timeout", type=int, default=None, help="time limit for tuning in seconds")
     args = parser.parse_args()
+
+    if args.task == "patchtst_grid":
+        run_patchtst_grid_search(args.config)
+        return
 
     if args.lgbm:
         tune_lgbm(args.n_trials, args.timeout, args.search)

--- a/README.md
+++ b/README.md
@@ -7,3 +7,11 @@ Run baseline models with the provided configuration:
 ```bash
 python LGHackerton/train_baseline.py --config configs/baseline.yaml --model naive
 ```
+
+## PatchTST Grid Search
+
+Run a grid search over PatchTST settings:
+
+```bash
+python LGHackerton/tune.py --task patchtst_grid --config configs/patchtst.yaml
+```

--- a/configs/patchtst.yaml
+++ b/configs/patchtst.yaml
@@ -1,0 +1,8 @@
+seed: 42
+val_policy: rocv
+rocv_n_folds: 1
+rocv_stride_days: 7
+rocv_val_span_days: 7
+purge_days: 28
+use_weighted_loss: true
+priority_weight: 3.0


### PR DESCRIPTION
## Summary
- add RevIN/per-series normalization option in PatchTSTTrainer
- implement PatchTST grid search runner with logging and CSV output
- expose `--task patchtst_grid` CLI and example configuration

## Testing
- `python -m py_compile LGHackerton/models/patchtst_trainer.py LGHackerton/tune.py`
- `python LGHackerton/tune.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a1cae545f48328af01b23b56cbc467