### PR TITLE
Remove BOM stripping from submission columns

### DIFF
--- a/LGHackerton/predict.py
+++ b/LGHackerton/predict.py
@@ -35,7 +35,7 @@ def _read_table(path: str) -> pd.DataFrame:
 
 def convert_to_submission(pred_df: pd.DataFrame, sample_path: str) -> pd.DataFrame:
     sample_df = _read_table(sample_path)
-    sample_df.columns = sample_df.columns.str.strip().str.lstrip("\ufeff")
+    sample_df.columns = sample_df.columns.str.strip()
 
     pred_df = pred_df.copy()
     pred_df["series_id"] = pred_df["series_id"].str.replace("::", "_", n=1)


### PR DESCRIPTION
## Summary
- Simplify submission column cleanup by removing BOM-specific lstrip in `convert_to_submission`

## Testing
- `PYTHONPATH=LGHackerton python -m LGHackerton.predict` *(fails: No such file or directory: '.../lgbm_models.json')*
- `python - <<'PY' ... convert_to_submission ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68a1e8648c908328b0afe4defb9fe716