### PR TITLE
Inject LGBM training data into tuning workflow

### DIFF
--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -96,7 +96,12 @@ def main(show_progress: bool | None = None):
     if not args.skip_tune:
         study_file = Path(OPTUNA_DIR) / "lgbm_study.json"
         if args.force_tune or not study_file.exists():
-            tune_lgbm(args.trials, args.timeout)
+            tune_lgbm(
+                args.trials,
+                args.timeout,
+                train_df=lgbm_train,
+                feature_cols=pp.feature_cols,
+            )
     lgbm_params_dict = load_best_lgbm_params()
     lgb_params = LGBMParams(**lgbm_params_dict)
 


### PR DESCRIPTION
## Summary
- Allow tune utility to accept preprocessed LightGBM training data and features
- Inject training frame and feature list from `train.py` when running Optuna tuning

## Testing
- `python -m pytest`
- `python -m py_compile LGHackerton/tune.py LGHackerton/train.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1e8ea5168832882fc5c0daaea9f89