### PR TITLE
Ensure submission columns match sample

### DIFF
--- a/LGHackerton/predict.py
+++ b/LGHackerton/predict.py
@@ -35,7 +35,6 @@ def _read_table(path: str) -> pd.DataFrame:
 
 def convert_to_submission(pred_df: pd.DataFrame, sample_path: str) -> pd.DataFrame:
     sample_df = _read_table(sample_path)
-    sample_df.columns = sample_df.columns.str.strip()
 
     pred_df = pred_df.copy()
     pred_df["series_id"] = pred_df["series_id"].str.replace("::", "_", n=1)
@@ -53,6 +52,7 @@ def convert_to_submission(pred_df: pd.DataFrame, sample_path: str) -> pd.DataFra
 
     out_df = sample_df.copy()
     out_df.iloc[:, 1:] = wide.to_numpy()
+    assert list(out_df.columns) == list(sample_df.columns)
     return out_df
 
 def main():


### PR DESCRIPTION
## Summary
- Remove column stripping from submission sample loader
- Verify assembled submission columns match the sample template

## Testing
- `pytest`
- Generated sample submission via `convert_to_submission` to ensure header match

------
https://chatgpt.com/codex/tasks/task_e_68a27ce2774483289f807605f4510c77