### PR TITLE
Clarify ROCV mask to prevent fold overlap

### DIFF
--- a/LGHackerton/models/patchtst_trainer.py
+++ b/LGHackerton/models/patchtst_trainer.py
@@ -156,7 +156,7 @@ def _make_rocv_slices(
 
     n = len(label_dates)
     slices: List[Tuple[np.ndarray, np.ndarray]] = []
-    used = np.zeros(n, dtype=bool)
+    used = np.zeros(n, dtype=bool)  # prevents overlap among folds
     dates = np.sort(np.unique(label_dates))
 
     for i in range(n_folds):


### PR DESCRIPTION
## Summary
- Document use of a `used` mask in `_make_rocv_slices` to ensure ROCV folds do not overlap.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a285dd7c988328983be2e8ea4c1cce