### PR TITLE
Add tests for PatchTST ROCV callbacks and logging

### DIFF
--- a/tests/test_patchtst_callback.py
+++ b/tests/test_patchtst_callback.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pathlib
+import sys
+
+# Add project root to sys.path for module imports
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from LGHackerton.models.patchtst_trainer import PatchTSTTrainer, _make_rocv_slices
+from LGHackerton.models.base_trainer import TrainConfig
+
+
+def test_register_rocv_callback_invokes_for_each_fold():
+    """Registered ROCV callbacks execute once per generated fold."""
+    dates = np.array("2024-01-01", dtype="datetime64[D]") + np.arange(30)
+    folds = _make_rocv_slices(
+        dates,
+        n_folds=2,
+        stride=3,
+        span=7,
+        purge=np.timedelta64(0, "D"),
+    )
+    cfg = TrainConfig(seed=123)
+    calls = []
+
+    def cb(seed, fold_idx, tr_mask, va_mask, cfg_inner):
+        calls.append((seed, fold_idx, tr_mask.copy(), va_mask.copy()))
+
+    original_callbacks = list(PatchTSTTrainer._rocv_callbacks)
+    PatchTSTTrainer._rocv_callbacks = []
+    try:
+        PatchTSTTrainer.register_rocv_callback(cb)
+        PatchTSTTrainer._notify_rocv_callbacks(cfg.seed, folds, cfg)
+    finally:
+        PatchTSTTrainer._rocv_callbacks = original_callbacks
+
+    assert len(calls) == len(folds)
+    for call, (tr, va) in zip(calls, folds):
+        assert np.array_equal(call[2], tr)
+        assert np.array_equal(call[3], va)

--- a/tests/test_patchtst_logging_adapter.py
+++ b/tests/test_patchtst_logging_adapter.py
@@ -1,0 +1,51 @@
+import numpy as np
+import pathlib
+import sys
+import pytest
+
+# Ensure project root is on sys.path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from LGHackerton.models.base_trainer import TrainConfig
+import LGHackerton.models.patchtst_trainer as pt
+from LGHackerton.train import _patch_patchtst_logging
+
+
+def test_fallback_wraps_make_rocv_slices(monkeypatch):
+    """Without ``register_rocv_callback`` fall back to wrapping ``_make_rocv_slices``."""
+    cfg = TrainConfig(seed=5)
+    calls = []
+
+    # Remove modern callback API
+    monkeypatch.delattr(pt.PatchTSTTrainer, "register_rocv_callback", raising=False)
+
+    # Capture fold logging
+    import LGHackerton.train as train_mod
+
+    def fake_log(seed, fold_idx, tr_mask, va_mask, cfg_inner, prefix):
+        calls.append((seed, fold_idx))
+
+    monkeypatch.setattr(train_mod, "_log_fold_start", fake_log)
+
+    with pytest.warns(UserWarning, match="register_rocv_callback not found"):
+        _patch_patchtst_logging(cfg)
+
+    dates = np.array("2024-01-01", dtype="datetime64[D]") + np.arange(20)
+    pt._make_rocv_slices(
+        dates,
+        n_folds=2,
+        stride=3,
+        span=7,
+        purge=np.timedelta64(0, "D"),
+    )
+    assert len(calls) == 2
+
+
+def test_no_hooks_warns(monkeypatch):
+    """Warn when neither callback nor slice hook exists."""
+    cfg = TrainConfig()
+    monkeypatch.delattr(pt.PatchTSTTrainer, "register_rocv_callback", raising=False)
+    monkeypatch.delattr(pt, "_make_rocv_slices", raising=False)
+
+    with pytest.warns(UserWarning, match="No PatchTST fold logging hooks found"):
+        _patch_patchtst_logging(cfg)


### PR DESCRIPTION
## Summary
- add tests ensuring `register_rocv_callback` fires for each ROCV fold
- verify fallback logging behavior when callbacks are unavailable
- confirm ROCV slices remain unique via existing regression test

## Testing
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a29e6453f083288033c0a8deae4c85