### PR TITLE
Document callback API and legacy fallback

### DIFF
--- a/docs/callbacks.md
+++ b/docs/callbacks.md
@@ -1,0 +1,23 @@
+# ROCV Callbacks
+
+`PatchTSTTrainer` provides a callback hook that fires after rolling-origin
+cross-validation (ROCV) slices are generated and before training begins.
+Callbacks receive `(seed, fold_idx, train_mask, val_mask, cfg)` and run once
+for every fold.
+
+```python
+from LGHackerton.models.patchtst_trainer import PatchTSTTrainer
+
+def log_fold(seed, fold_idx, tr_mask, va_mask, cfg):
+    print(f"fold {fold_idx} -> {tr_mask.sum()} train / {va_mask.sum()} val")
+
+PatchTSTTrainer.register_rocv_callback(log_fold)
+```
+
+Failures inside the callback are isolated from training: the trainer converts
+exceptions into warnings so that logging issues do not interrupt model fitting.
+
+The public callback API intentionally avoids exposing private helpers.
+Older versions without ``register_rocv_callback`` required wrapping the
+private ``_make_rocv_slices`` function; ``train.py`` still supports this
+as a legacy fallback.


### PR DESCRIPTION
## Summary
- clarify PatchTSTTrainer ROCV callback lifecycle and failure isolation
- describe train-time logging hook and legacy fallback in comments
- add developer docs on registering callbacks for fold logging

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2a02492a0832893acb26b5a6bf5ce