### PR TITLE
feat: make promotion feature optional

### DIFF
--- a/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
+++ b/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
@@ -253,6 +253,7 @@ class CalendarFeatureMaker:
         self._woy_cols: List[str] = []
         self._month_cols: List[str] = []
         self._promo_col: Optional[str] = None
+        self._feature_names: List[str] = []
 
     def fit(self, df: pd.DataFrame):
         years = df[DATE_COL].dt.year.unique().tolist()
@@ -268,6 +269,20 @@ class CalendarFeatureMaker:
             if c in df.columns
         ]
         self._promo_col = promo_candidates[0] if promo_candidates else None
+        self._feature_names = [
+            "year",
+            "day",
+            "dow",
+            "is_weekend",
+            "is_month_start",
+            "is_month_end",
+            "is_holiday",
+            "is_priority_outlet",
+            *self._month_cols,
+            *self._woy_cols,
+        ]
+        if self._promo_col is not None:
+            self._feature_names.append("is_promo")
         return self
 
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -295,8 +310,6 @@ class CalendarFeatureMaker:
 
         if self._promo_col is not None and self._promo_col in df.columns:
             d["is_promo"] = df[self._promo_col].astype(np.int8)
-        else:
-            d["is_promo"] = 0
 
         d["is_priority_outlet"] = d[SHOP_COL].isin(PRIORITY_OUTLETS).astype(np.int8)
         return d


### PR DESCRIPTION
## Summary
- Only generate `is_promo` calendar feature when a promotion column exists
- Track calendar feature names and skip `is_promo` if source is missing

## Testing
- `pytest -q`
- `python - <<'PY'
import glob
import pandas as pd
import lightgbm as lgb
from LGHackerton.preprocess import Preprocessor
from LGHackerton.config.default import TRAIN_PATH, TEST_GLOB

train_df = pd.read_csv(TRAIN_PATH).head(1000)
pp = Preprocessor(show_progress=False)
train_full = pp.fit_transform_train(train_df)

lgbm_train = pp.build_lgbm_train(train_full)
X = lgbm_train[pp.feature_cols]
y = lgbm_train['y']
train_set = lgb.Dataset(X, label=y)
model = lgb.train({'objective': 'regression', 'verbose': -1}, train_set, num_boost_round=10)

files = sorted(glob.glob(TEST_GLOB))
eval_df_raw = pd.read_csv(files[0]).head(1000)
eval_full = pp.transform_eval(eval_df_raw)

lgbm_eval = pp.build_lgbm_eval(eval_full)
print('train shape', lgbm_train.shape)
print('eval shape', lgbm_eval.shape)
print('feature count', len(pp.feature_cols))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a329b96e088328817fb99e2d9fda1b