### PR TITLE
feat: add input length search for PatchTST

### DIFF
--- a/LGHackerton/models/base_trainer.py
+++ b/LGHackerton/models/base_trainer.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 @dataclass
 class TrainConfig:
@@ -24,6 +24,7 @@ class TrainConfig:
     purge_days:int=0                 # explicit purge gap (0 -> derive from purge_mode)
     min_val_samples:int=28           # minimum validation samples per fold
     purge_mode:str="L"               # fallback for legacy behaviour
+    input_lens: List[int] | None = None
 
 class BaseModel(ABC):
     def __init__(self, model_params: Dict[str, Any], model_dir: str):

--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -275,7 +275,7 @@ def main(show_progress: bool | None = None):
     if TORCH_OK and not args.skip_tune and patch_input_len is None:
         patch_file = Path(OPTUNA_DIR) / "patchtst_best.json"
         if args.force_tune or not patch_file.exists():
-            tune_patchtst(X_train, y_train, series_ids, label_dates, cfg)
+            tune_patchtst(pp, df_full, cfg)
         patch_params_dict, _ = load_best_patch_params()
 
     if TORCH_OK:

--- a/configs/baseline.yaml
+++ b/configs/baseline.yaml
@@ -4,3 +4,4 @@ rocv_n_folds: 3
 rocv_stride_days: 7
 rocv_val_span_days: 7
 purge_days: 28
+input_lens: [96, 168, 336]


### PR DESCRIPTION
## Summary
- support tuning multiple input lengths for PatchTST with dataset caching
- expose `input_lens` field in `TrainConfig` and configs
- update CLI and training pipeline to use preprocessor directly when tuning

## Testing
- `pytest`
- `python LGHackerton/tune.py --patch --n-trials 1 --timeout 1` *(fails: KeyboardInterrupt during training)*

------
https://chatgpt.com/codex/tasks/task_e_68a33cde708c832896ad937ecbd2ceca