### PR TITLE
Allow broadcasted weights in HybridLoss

### DIFF
--- a/LGHackerton/models/patchtst/train.py
+++ b/LGHackerton/models/patchtst/train.py
@@ -82,7 +82,8 @@ class HybridLoss(nn.Module):
         l1 = self.l1(y_pred, y_true)
         smape = self.smape(y_pred, y_true)
         if w is not None:
-            w = w.view_as(l1)
+            if w.ndim == 1:
+                w = w.unsqueeze(1)
             l1 = l1 * w
             smape = smape * w
         loss = self.alpha * l1 + (1.0 - self.alpha) * smape


### PR DESCRIPTION
## Summary
- support broadcastable sample weights in PatchTST HybridLoss

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a35acb39d88328a7d120bd1351df9d