### PR TITLE
refactor: centralize artifacts path usage

### DIFF
--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -162,8 +162,10 @@ def load_best_patch_params() -> tuple[dict, int | None]:
         Lookback length if determined from grid search, otherwise ``None``.
     """
 
+    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+
     # 1) Grid search CSV
-    search_path = Path("artifacts") / "patchtst_search.csv"
+    search_path = ARTIFACTS_DIR / "patchtst_search.csv"
     if search_path.exists():
         try:
             df = pd.read_csv(search_path)

--- a/LGHackerton/tune.py
+++ b/LGHackerton/tune.py
@@ -555,8 +555,8 @@ def run_patchtst_grid_search(cfg_path: str | Path) -> None:
                 )
                 continue
 
-    os.makedirs("artifacts", exist_ok=True)
-    pd.DataFrame(results).to_csv(Path("artifacts") / "patchtst_search.csv", index=False)
+    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(results).to_csv(ARTIFACTS_DIR / "patchtst_search.csv", index=False)
 
 
 def main() -> None:  # pragma: no cover - CLI entry point


### PR DESCRIPTION
## Summary
- use `ARTIFACTS_DIR` constant instead of hard-coded `Path('artifacts')`
- ensure grid search output path exists before writing results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3b6b70b848328ad0288b296c456b9