### PR TITLE
Ensure iterable input lens for PatchTST tuning

### DIFF
--- a/LGHackerton/tune.py
+++ b/LGHackerton/tune.py
@@ -328,7 +328,9 @@ def tune_patchtst(pp, df_full, cfg):
     study = optuna.create_study(direction="minimize")
 
     dataset_cache: dict[int, tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = {}
-    input_lens = getattr(cfg, "input_lens", [96, 168, 336])
+    input_lens = getattr(cfg, "input_lens", None) or [96, 168, 336]
+    if not isinstance(input_lens, (list, tuple)):
+        input_lens = [input_lens]
 
     def objective(trial: optuna.Trial) -> float:
         """Train a PatchTST model for a single Optuna trial.


### PR DESCRIPTION
## Summary
- Ensure PatchTST tuning defaults to `[96, 168, 336]` when `cfg.input_lens` is `None`
- Normalize `input_lens` to an iterable before Optuna categorical suggestion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3d3f285908328a2df0a5cc146ad8c