### PR TITLE
Expand PatchTST patch length search space

### DIFF
--- a/LGHackerton/tune.py
+++ b/LGHackerton/tune.py
@@ -410,7 +410,10 @@ def tune_patchtst(pp, df_full, cfg):
                 "max_epochs": trial.suggest_int("max_epochs", 50, 200),
                 "patience": trial.suggest_int("patience", 5, 30),
             }
-            patch_len = trial.suggest_categorical("patch_len", 14)
+            patch_len = trial.suggest_categorical(
+                "patch_len",
+                [8, 12, 14, 16, 24],
+            )
             sampled_params["patch_len"] = patch_len
             sampled_params["stride"] = patch_len
             if input_len % patch_len != 0:


### PR DESCRIPTION
## Summary
- Allow Optuna to sample PatchTST patch lengths from a list of options
- Retain divisibility check to prune incompatible patch lengths

## Testing
- `pytest -q`
- `python - <<'PY'
import optuna
for input_len in [96,168,336]:
    for patch_len in [8,12,14,16,24]:
        pruned = input_len % patch_len != 0
        print(f"{input_len} % {patch_len} = {input_len % patch_len} -> {'pruned' if pruned else 'ok'}")
PY`
- `python - <<'PY'
import optuna
input_len=96
patch_len=14
try:
    if input_len % patch_len != 0:
        raise optuna.TrialPruned()
    print("pass")
except optuna.TrialPruned:
    print("TrialPruned raised as expected")
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a3d5fe178483289ede5700905dbecb