### PR TITLE
Use probability multiplication for hurdle models

### DIFF
--- a/LGHackerton/models/lgbm_trainer.py
+++ b/LGHackerton/models/lgbm_trainer.py
@@ -182,6 +182,8 @@ class LGBMTrainer(BaseModel):
                     yhat = np.clip(prob * reg_pred, 0.0, None)
                     oof_df = dfh.loc[va_mask, ["series_id", "h"]].copy()
                     oof_df["y"] = y_va
+                    oof_df["prob"] = prob
+                    oof_df["reg_pred"] = reg_pred
                     oof_df["yhat"] = yhat
                     self.oof_records.extend(oof_df.to_dict("records"))
                 else:
@@ -268,6 +270,7 @@ class LGBMTrainer(BaseModel):
                     prob_mean = np.mean(np.stack(clf_list, axis=0), axis=0)
                 else:
                     prob_mean = 1.0
+                # combine classifier and regressor via probability multiplication
                 preds[mask] = np.clip(prob_mean * reg_mean, 0.0, None)
             else:
                 preds[mask] = reg_mean

--- a/LGHackerton/tune.py
+++ b/LGHackerton/tune.py
@@ -39,6 +39,7 @@ from LGHackerton.config.default import OPTUNA_DIR, TRAIN_PATH, TRAIN_CFG, ARTIFA
 from LGHackerton.preprocess import Preprocessor
 from LGHackerton.models.base_trainer import TrainConfig
 from LGHackerton.models.lgbm_trainer import LGBMParams, LGBMTrainer
+from LGHackerton.models.lightgbm.train import combine_with_regression
 from LGHackerton.utils.metrics import weighted_smape_np
 from LGHackerton.utils.seed import set_seed
 
@@ -301,6 +302,9 @@ def objective_lgbm_hurdle(trial: optuna.Trial) -> float:
 
         oof = trainer.get_oof()
         outlets = oof["series_id"].str.split("::").str[0].values
+        if {"prob", "reg_pred"}.issubset(oof.columns):
+            # ensure the same probability-multiplication logic is used during tuning
+            oof["yhat"] = combine_with_regression(oof["prob"].values, oof["reg_pred"].values)
         score = weighted_smape_np(
             oof["y"].values,
             oof["yhat"].values,

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # BellmanPredict
 
+## Hurdle Model Combination
+
+Throughout the project, binary classification probabilities and regression
+forecasts are combined using probability multiplication. The final demand
+estimate for each horizon is computed as ``p * \hat{y}``, where ``p`` is the
+predicted probability of non-zero demand. This convention is implemented in
+`LGBMTrainer`, the standalone LightGBM utilities, and the Optuna tuning
+objective.
+
 ## Baseline Forecasting
 
 Run baseline models with the provided configuration:


### PR DESCRIPTION
## Summary
- Document probability-multiplication strategy for hurdle models
- Multiply classifier probability and regression forecast in LightGBM utilities and trainer
- Ensure Optuna tuning recombines predictions with the same logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3f422aae483289468ccea6482b59c