### PR TITLE
refactor: enhance LGBM tuning horizon validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,13 @@ python LGHackerton/tune.py --task patchtst_grid --config configs/patchtst.yaml
    used.
 
 This avoids confusion when both grid-search and Optuna artifacts may exist.
+
+## LightGBM 튜닝 강화 로직
+
+`LGHackerton/tune.py` 의 `objective_lgbm` 함수는 각 horizon 별로 데이터 품질을
+검증한 후 학습을 진행하도록 개선되었습니다. 샘플 수가 100건 미만이거나
+80% 이상이 상수 피처인 경우, 유효 피처가 5개 미만인 경우, 날짜 범위가
+10일 미만인 경우에는 해당 horizon 을 건너뜁니다. 양성 비율이 1% 미만일 때도
+학습을 수행하지 않습니다. 또한 분산이 낮은 피처는 제거되며 양성 샘플에는
+가중치 2.0 이 적용됩니다. 이러한 검증 로직은 불필요한 경고를 줄이고,
+하이퍼파라미터 탐색의 안정성을 높이기 위해 도입되었습니다.


### PR DESCRIPTION
## Summary
- strengthen `objective_lgbm` with per-horizon data validation and sample weighting
- document LightGBM tuning safeguards in README

## Testing
- `python -m py_compile LGHackerton/tune.py`
- `pytest -q`
- `python LGHackerton/tune.py --lgbm --n-trials 1` *(fails: Training data has not been provided)*

------
https://chatgpt.com/codex/tasks/task_e_68a52b2faca083288d3f7e44985f9385