### PR TITLE
Reduce min_data_in_leaf upper bound to 20

### DIFF
--- a/LGHackerton/tune.py
+++ b/LGHackerton/tune.py
@@ -239,7 +239,7 @@ def objective_lgbm(trial: optuna.Trial) -> float:
 
             n_samples = len(y_tr)
             lower_bound = max(int(n_samples * 0.01), 1)
-            upper_bound = min(int(n_samples * 0.10), 50)
+            upper_bound = min(int(n_samples * 0.10), 20)
             if upper_bound < lower_bound:
                 upper_bound = lower_bound
 


### PR DESCRIPTION
## Summary
- cap LightGBM tuning parameter `min_data_in_leaf` at 20 samples
- preserve safeguard when cap drops below computed lower bound

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5308b11448328a2a05f2a24385f0e