### PR TITLE
Emphasize non-zero samples in SMAPE loss

### DIFF
--- a/LGHackerton/models/base_trainer.py
+++ b/LGHackerton/models/base_trainer.py
@@ -11,6 +11,7 @@ class TrainConfig:
     cv_stride:int=7
     priority_weight:float=3.0
     use_weighted_loss:bool=False
+    non_zero_weight:float=2.0
     use_asinh_target:bool=False
     use_hurdle:bool=False
     model_dir:str="./artifacts"


### PR DESCRIPTION
## Summary
- add configurable `non_zero_weight` for training
- compute per-series zero-rate weights and emphasize non-zero samples in PatchTST training
- extend `weighted_smape_np` to handle series-based weighting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a563edacf48328bb3d9aa4b76496f4