### PR TITLE
Expose Ljung-Box residuals and log diagnostics input

### DIFF
--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -231,15 +231,26 @@ def main(show_progress: bool | None = None):
             diag_dir.mkdir(parents=True, exist_ok=True)
             acf_df = compute_acf(res_p)
             pacf_df = compute_pacf(res_p)
-            lb_df = ljung_box_test(res_p, lags=[10, 20, 30])
+            lb_df, res_used = ljung_box_test(
+                res_p, lags=[10, 20, 30], return_residuals=True
+            )
             wt_df = white_test(res_p)
             acf_df.to_csv(diag_dir / "acf.csv", index=False)
             pacf_df.to_csv(diag_dir / "pacf.csv", index=False)
             lb_df.to_csv(diag_dir / "ljung_box.csv", index=False)
+            res_used.rename("residual").to_csv(
+                diag_dir / "ljung_box_input.csv", index=False
+            )
             wt_df.to_csv(diag_dir / "white_test.csv", index=False)
             plot_residuals(res_p, diag_dir)
             logging.info("PatchTST Ljung-Box p-values: %s", lb_df["pvalue"].tolist())
-            logging.info("PatchTST White test p-value: %s", wt_df["lm_pvalue"].iloc[0])
+            logging.info(
+                "PatchTST Ljung-Box residual sample: %s",
+                res_used.head().tolist(),
+            )
+            logging.info(
+                "PatchTST White test p-value: %s", wt_df["lm_pvalue"].iloc[0]
+            )
         except Exception as e:  # pragma: no cover - best effort
             logging.warning("PatchTST diagnostics failed: %s", e)
 

--- a/LGHackerton/utils/diagnostics.py
+++ b/LGHackerton/utils/diagnostics.py
@@ -69,8 +69,28 @@ def compute_pacf(residuals: pd.Series, nlags: int = 40) -> pd.DataFrame:
     )
 
 
-def ljung_box_test(residuals: pd.Series, lags: List[int]) -> pd.DataFrame:
-    """Ljung-Box test for autocorrelation."""
+def ljung_box_test(
+    residuals: pd.Series, lags: List[int], *, return_residuals: bool = False
+) -> pd.DataFrame | tuple[pd.DataFrame, pd.Series]:
+    """Ljung-Box test for autocorrelation.
+
+    Parameters
+    ----------
+    residuals : pd.Series
+        Raw residual series which may contain ``NaN`` values.
+    lags : List[int]
+        Lags at which to evaluate the Ljung-Box statistic.
+    return_residuals : bool, optional
+        When ``True``, also return the validated residual series after dropping
+        ``NaN`` values and enforcing minimum length requirements.
+
+    Returns
+    -------
+    pd.DataFrame or tuple
+        DataFrame containing Ljung-Box statistics and p-values. If
+        ``return_residuals`` is ``True``, a tuple of the DataFrame and the
+        validated residual :class:`pandas.Series` is returned.
+    """
     if not lags:
         raise ValueError("lags must be a non-empty list")
     max_lag = max(lags)
@@ -82,6 +102,8 @@ def ljung_box_test(residuals: pd.Series, lags: List[int]) -> pd.DataFrame:
     lb = acorr_ljungbox(res, lags=lags, return_df=True)
     lb = lb.rename(columns={"lb_stat": "stat", "lb_pvalue": "pvalue"})
     lb.insert(0, "lag", lags)
+    if return_residuals:
+        return lb, res
     return lb
 
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,13 @@
+import numpy as np
+import pandas as pd
+
+from LGHackerton.utils.diagnostics import ljung_box_test
+
+
+def test_ljung_box_test_returns_residuals():
+    """ljung_box_test returns validated residuals when requested."""
+    series = pd.Series([1.0, 2.0, np.nan, 4.0, 5.0])
+    lb, res = ljung_box_test(series, lags=[2], return_residuals=True)
+    # Ensure returned DataFrame has expected column and residuals are cleaned
+    assert "pvalue" in lb.columns
+    assert res.equals(series.dropna())


### PR DESCRIPTION
## Summary
- add `return_residuals` flag to `ljung_box_test` to optionally return cleaned residuals
- capture residuals in training diagnostics and save sample to artifacts
- add unit test covering new `ljung_box_test` option

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5aef304b083289fb81fb4d5e99e18