### PR TITLE
Ensure PatchTST stride matches patch length

### DIFF
--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -158,6 +158,7 @@ def load_best_patch_params() -> tuple[dict, int | None]:
     try:
         with best_path.open("r", encoding="utf-8") as f:
             patch_best = json.load(f)
+        patch_best.setdefault("stride", patch_best.get("patch_len", PATCH_PARAMS["patch_len"]))
         input_len = patch_best.pop("input_len", None)
         return {**PATCH_PARAMS, **patch_best}, input_len
     except Exception as e:  # pragma: no cover - best effort

--- a/LGHackerton/tune.py
+++ b/LGHackerton/tune.py
@@ -252,7 +252,8 @@ def tune_patchtst(pp, df_full, cfg):
     best_path = OPTUNA_DIR / "patchtst_best.json"
     best_path.parent.mkdir(parents=True, exist_ok=True)
     with best_path.open("w", encoding="utf-8") as f:
-        json.dump(study.best_params, f, ensure_ascii=False, indent=2)
+        best = {**study.best_params, "stride": study.best_params["patch_len"]}
+        json.dump(best, f, ensure_ascii=False, indent=2)
 
     return study
 


### PR DESCRIPTION
## Summary
- include `stride` when saving Optuna best parameters
- default missing `stride` to `patch_len` when loading best PatchTST params

## Testing
- `pytest -q`
- `python - <<'PY'
from LGHackerton.train import load_best_patch_params
from LGHackerton.models.patchtst_trainer import PatchTSTParams
params_dict, _ = load_best_patch_params()
params = PatchTSTParams(**params_dict)
print('patch_len:', params.patch_len, 'stride:', params.stride)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a5afebe3b483288ff55b4363d7dcd2