### PR TITLE
Allow configuring DataLoader workers

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -41,6 +41,7 @@ PATCH_PARAMS = dict(
     id_embed_dim=16,
     lr=1e-3, weight_decay=1e-4, batch_size=256,
     max_epochs=200, patience=20,
+    num_workers=0,
 )
 TRAIN_CFG = dict(
     seed=42, n_folds=3, cv_stride=7,

--- a/LGHackerton/tune.py
+++ b/LGHackerton/tune.py
@@ -31,7 +31,7 @@ try:  # torch is optional; used only for GPU cache clearing
 except Exception:  # pragma: no cover - torch optional
     torch = None  # type: ignore
 
-from LGHackerton.config.default import OPTUNA_DIR, TRAIN_PATH, TRAIN_CFG, ARTIFACTS_DIR
+from LGHackerton.config.default import OPTUNA_DIR, TRAIN_PATH, TRAIN_CFG, ARTIFACTS_DIR, PATCH_PARAMS
 from LGHackerton.preprocess import Preprocessor
 from LGHackerton.models.base_trainer import TrainConfig
 from LGHackerton.utils.metrics import weighted_smape_np
@@ -200,6 +200,7 @@ def tune_patchtst(pp, df_full, cfg):
             )
             sampled_params["patch_len"] = patch_len
             sampled_params["stride"] = patch_len
+            sampled_params["num_workers"] = PATCH_PARAMS.get("num_workers", 0)
             if input_len % patch_len != 0:
                 raise optuna.TrialPruned()
 
@@ -304,7 +305,11 @@ def run_patchtst_grid_search(cfg_path: str | Path) -> None:
             try:
                 set_seed(42)
                 params = PatchTSTParams(
-                    patch_len=patch, stride=patch, lr=lr, scaler=scaler
+                    patch_len=patch,
+                    stride=patch,
+                    lr=lr,
+                    scaler=scaler,
+                    num_workers=PATCH_PARAMS.get("num_workers", 0),
                 )
                 trainer = PatchTSTTrainer(
                     params=params, L=inp, H=H, model_dir=cfg.model_dir, device=device


### PR DESCRIPTION
## Summary
- add `num_workers` to `PatchTSTParams` and pass to DataLoader in training and prediction
- expose `num_workers` via default config and tuning utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5b514ab0483288f6ebfba0d4de936