### PR TITLE
Add hyperparameter tuners for LGBM and TFT

### DIFF
--- a/LGHackerton/tuning/lgbm.py
+++ b/LGHackerton/tuning/lgbm.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import gc
+from dataclasses import asdict, dataclass, fields
+from typing import List, Tuple
+
+import optuna
+import pandas as pd
+
+from LGHackerton.models.lgbm_trainer import LGBMParams, LGBMTrainer
+from LGHackerton.tuning.base import HyperparameterTuner
+from LGHackerton.utils.metrics import weighted_smape_np
+from LGHackerton.utils.seed import set_seed
+
+
+@dataclass
+class LGBMSearchSpace:
+    """Search space for LightGBM hyperparameters."""
+
+    num_leaves: Tuple[int, int] = (31, 255)
+    max_depth: Tuple[int, int] = (3, 16)
+    learning_rate: Tuple[float, float] = (1e-3, 0.3)
+    subsample: Tuple[float, float] = (0.5, 1.0)
+    colsample_bytree: Tuple[float, float] = (0.5, 1.0)
+    min_data_in_leaf: Tuple[int, int] = (10, 200)
+    reg_alpha: Tuple[float, float] = (1e-8, 1.0)
+    reg_lambda: Tuple[float, float] = (1e-8, 1.0)
+    n_estimators: Tuple[int, int] = (500, 4000)
+
+
+class LGBMTuner(HyperparameterTuner):
+    """Optuna tuner for the LightGBM model."""
+
+    search_space: LGBMSearchSpace = LGBMSearchSpace()
+
+    def __init__(self, pp, df, cfg) -> None:  # type: ignore[override]
+        super().__init__(pp, df, cfg)
+        self._dataset: tuple[pd.DataFrame, List[str]] | None = None
+
+    # ------------------------------------------------------------------
+    # Utility methods
+    # ------------------------------------------------------------------
+    def prepare_dataset(self) -> tuple[pd.DataFrame, List[str]]:
+        """Build the training dataframe and feature list."""
+
+        if self._dataset is None:
+            df_train = self.pp.build_lgbm_train(self.df)
+            feats = list(self.pp.feature_cols)
+            self._dataset = (df_train, feats)
+        return self._dataset
+
+    # ------------------------------------------------------------------
+    # Core API
+    # ------------------------------------------------------------------
+    def validate_params(self, params: dict) -> None:  # type: ignore[override]
+        required = {f.name for f in fields(LGBMParams)}
+        missing = required - params.keys()
+        if missing:
+            raise ValueError(f"Missing hyperparameters: {sorted(missing)}")
+        s = self.search_space
+        int_fields = {
+            "num_leaves": s.num_leaves,
+            "max_depth": s.max_depth,
+            "min_data_in_leaf": s.min_data_in_leaf,
+            "n_estimators": s.n_estimators,
+        }
+        for name, (lo, hi) in int_fields.items():
+            val = params.get(name)
+            if not isinstance(val, int) or not (lo <= val <= hi):
+                raise ValueError(f"{name}={val} outside [{lo}, {hi}]")
+        float_fields = {
+            "learning_rate": s.learning_rate,
+            "subsample": s.subsample,
+            "colsample_bytree": s.colsample_bytree,
+            "reg_alpha": s.reg_alpha,
+            "reg_lambda": s.reg_lambda,
+        }
+        for name, (lo, hi) in float_fields.items():
+            val = params.get(name)
+            if not isinstance(val, (float, int)) or not (lo <= float(val) <= hi):
+                raise ValueError(f"{name}={val} outside [{lo}, {hi}]")
+
+    def run(self, n_trials: int, force: bool = False) -> dict:  # type: ignore[override]
+        df_train, feat_cols = self.prepare_dataset()
+        study = optuna.create_study(direction="minimize")
+        search = self.search_space
+
+        def objective(trial: optuna.Trial) -> float:
+            set_seed(self.cfg.seed)
+            params = {
+                "num_leaves": trial.suggest_int("num_leaves", *search.num_leaves),
+                "max_depth": trial.suggest_int("max_depth", *search.max_depth),
+                "learning_rate": trial.suggest_float(
+                    "learning_rate", *search.learning_rate, log=True
+                ),
+                "subsample": trial.suggest_float("subsample", *search.subsample),
+                "colsample_bytree": trial.suggest_float(
+                    "colsample_bytree", *search.colsample_bytree
+                ),
+                "min_data_in_leaf": trial.suggest_int(
+                    "min_data_in_leaf", *search.min_data_in_leaf
+                ),
+                "reg_alpha": trial.suggest_float(
+                    "reg_alpha", *search.reg_alpha, log=True
+                ),
+                "reg_lambda": trial.suggest_float(
+                    "reg_lambda", *search.reg_lambda, log=True
+                ),
+                "n_estimators": trial.suggest_int(
+                    "n_estimators", *search.n_estimators
+                ),
+            }
+            trainer_params = LGBMParams(**params)
+            trainer = LGBMTrainer(
+                trainer_params,
+                feat_cols,
+                getattr(self.cfg, "model_dir", "."),
+                device="cpu",
+            )
+            trainer.train(df_train, self.cfg, preprocessors=[self.pp])
+            oof = trainer.get_oof()
+            if oof.empty:
+                raise optuna.TrialPruned()
+            outlets = oof["series_id"].str.split("::").str[0].values
+            score = weighted_smape_np(
+                oof["y"].to_numpy(),
+                oof["yhat"].to_numpy(),
+                outlets,
+                priority_weight=getattr(self.cfg, "priority_weight", 1.0),
+            )
+            gc.collect()
+            return float(score)
+
+        study.optimize(objective, n_trials=n_trials)
+        best = dict(study.best_trial.params)
+        params = LGBMParams(**best)
+        self._best_params = asdict(params)
+        self.validate_params(self._best_params)
+        return self._best_params

--- a/LGHackerton/tuning/tft.py
+++ b/LGHackerton/tuning/tft.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import gc
+from dataclasses import asdict, dataclass
+from typing import Tuple
+
+import optuna
+import numpy as np
+
+from LGHackerton.tuning.base import HyperparameterTuner
+from LGHackerton.utils.metrics import weighted_smape_np
+from LGHackerton.utils.seed import set_seed
+
+try:  # optional, trainer may not be present
+    from LGHackerton.models.tft_trainer import TFTParams, TFTTrainer  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    TFTParams = None  # type: ignore
+    TFTTrainer = None  # type: ignore
+
+try:  # torch is optional for CPU-only environments
+    import torch
+except Exception:  # pragma: no cover - torch optional
+    torch = None  # type: ignore
+
+
+@dataclass
+class TFTSearchSpace:
+    """Search space for TFT hyperparameters."""
+
+    hidden_size: Tuple[int, int] = (64, 512)
+    lstm_layers: Tuple[int, int] = (1, 4)
+    dropout: Tuple[float, float] = (0.0, 0.5)
+    attention_heads: Tuple[int, int] = (1, 8)
+    learning_rate: Tuple[float, float] = (1e-4, 1e-2)
+    batch_size: Tuple[int, int] = (32, 256)
+    max_epochs: Tuple[int, int] = (50, 200)
+    patience: Tuple[int, int] = (5, 30)
+
+
+class TFTTuner(HyperparameterTuner):
+    """Optuna tuner for Temporal Fusion Transformer models."""
+
+    search_space: TFTSearchSpace = TFTSearchSpace()
+
+    def __init__(self, pp, df, cfg) -> None:  # type: ignore[override]
+        super().__init__(pp, df, cfg)
+        self._dataset: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | None = None
+
+    # ------------------------------------------------------------------
+    # Utility methods
+    # ------------------------------------------------------------------
+    def prepare_dataset(self) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Construct training tensors for TFT."""
+
+        if self._dataset is None:
+            self._dataset = self.pp.build_patch_train(self.df)
+        return self._dataset
+
+    # ------------------------------------------------------------------
+    # Core API
+    # ------------------------------------------------------------------
+    def validate_params(self, params: dict) -> None:  # type: ignore[override]
+        required = {
+            "hidden_size",
+            "lstm_layers",
+            "dropout",
+            "attention_heads",
+            "learning_rate",
+            "batch_size",
+            "max_epochs",
+            "patience",
+        }
+        missing = required - params.keys()
+        if missing:
+            raise ValueError(f"Missing hyperparameters: {sorted(missing)}")
+        s = self.search_space
+        def _chk_int(name: str, bounds: Tuple[int, int]) -> None:
+            val = params.get(name)
+            if not isinstance(val, int) or not (bounds[0] <= val <= bounds[1]):
+                raise ValueError(f"{name}={val} outside [{bounds[0]}, {bounds[1]}]")
+        def _chk_float(name: str, bounds: Tuple[float, float]) -> None:
+            val = params.get(name)
+            if not isinstance(val, (float, int)) or not (bounds[0] <= float(val) <= bounds[1]):
+                raise ValueError(f"{name}={val} outside [{bounds[0]}, {bounds[1]}]")
+        _chk_int("hidden_size", s.hidden_size)
+        _chk_int("lstm_layers", s.lstm_layers)
+        _chk_float("dropout", s.dropout)
+        _chk_int("attention_heads", s.attention_heads)
+        _chk_float("learning_rate", s.learning_rate)
+        _chk_int("batch_size", s.batch_size)
+        _chk_int("max_epochs", s.max_epochs)
+        _chk_int("patience", s.patience)
+
+    def run(self, n_trials: int, force: bool = False) -> dict:  # type: ignore[override]
+        if TFTTrainer is None or TFTParams is None:
+            raise RuntimeError("TFTTrainer not available")
+        X, y, series_ids, label_dates = self.prepare_dataset()
+        study = optuna.create_study(direction="minimize")
+        search = self.search_space
+
+        def objective(trial: optuna.Trial) -> float:
+            set_seed(self.cfg.seed)
+            params = {
+                "hidden_size": trial.suggest_int("hidden_size", *search.hidden_size),
+                "lstm_layers": trial.suggest_int("lstm_layers", *search.lstm_layers),
+                "dropout": trial.suggest_float("dropout", *search.dropout),
+                "attention_heads": trial.suggest_int("attention_heads", *search.attention_heads),
+                "learning_rate": trial.suggest_float(
+                    "learning_rate", *search.learning_rate, log=True
+                ),
+                "batch_size": trial.suggest_int("batch_size", *search.batch_size),
+                "max_epochs": trial.suggest_int("max_epochs", *search.max_epochs),
+                "patience": trial.suggest_int("patience", *search.patience),
+            }
+            trainer_params = TFTParams(**params)
+            device = "cuda" if torch and torch.cuda.is_available() else "cpu"
+            trainer = TFTTrainer(
+                params=trainer_params,
+                L=X.shape[1],
+                H=y.shape[1],
+                model_dir=getattr(self.cfg, "model_dir", "."),
+                device=device,
+            )
+            trainer.train(X, y, series_ids, label_dates, self.cfg)
+            oof = trainer.get_oof()
+            outlets = oof["series_id"].str.split("::").str[0].values
+            score = weighted_smape_np(
+                oof["y"].to_numpy(),
+                oof["yhat"].to_numpy(),
+                outlets,
+                priority_weight=getattr(self.cfg, "priority_weight", 1.0),
+            )
+            gc.collect()
+            return float(score)
+
+        study.optimize(objective, n_trials=n_trials)
+        best = dict(study.best_trial.params)
+        params = TFTParams(**best)
+        self._best_params = asdict(params)
+        self.validate_params(self._best_params)
+        return self._best_params


### PR DESCRIPTION
## Summary
- add dataclass search spaces for LightGBM and TFT
- implement LGBMTuner and TFTTuner inheriting HyperparameterTuner
- include dataset preparation, Optuna search and parameter validation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5f798f9e08328b101ec81d5436582