### PR TITLE
feat: add tuner registry

### DIFF
--- a/LGHackerton/tuning/__init__.py
+++ b/LGHackerton/tuning/__init__.py
@@ -1,0 +1,20 @@
+"""Hyperparameter tuning utilities and registry."""
+
+from .registry import TunerRegistry
+from .patchtst import PatchTSTTuner
+
+TunerRegistry.register("patchtst", PatchTSTTuner)
+
+try:  # optional tuners
+    from .lgbm import LGBMTuner
+    TunerRegistry.register("lgbm", LGBMTuner)
+except Exception:  # pragma: no cover - optional
+    LGBMTuner = None  # type: ignore
+
+try:
+    from .tft import TFTTuner  # type: ignore
+    TunerRegistry.register("tft", TFTTuner)
+except Exception:  # pragma: no cover - optional
+    TFTTuner = None  # type: ignore
+
+__all__ = ["TunerRegistry", "PatchTSTTuner", "LGBMTuner", "TFTTuner"]

--- a/LGHackerton/tuning/registry.py
+++ b/LGHackerton/tuning/registry.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Registry for hyperparameter tuner classes."""
+
+from typing import Dict, Type
+
+from LGHackerton.tuning.base import HyperparameterTuner
+
+
+class TunerRegistry:
+    """Simple mapping from model name to its tuner class."""
+
+    _REGISTRY: Dict[str, Type[HyperparameterTuner]] = {}
+
+    @classmethod
+    def register(cls, name: str, tuner_cls: Type[HyperparameterTuner]) -> None:
+        """Register a tuner class under a given name."""
+        cls._REGISTRY[name] = tuner_cls
+
+    @classmethod
+    def get(cls, name: str) -> Type[HyperparameterTuner]:
+        """Retrieve the tuner class for ``name``.
+
+        Parameters
+        ----------
+        name : str
+            Name of the model/tuner.
+
+        Returns
+        -------
+        Type[HyperparameterTuner]
+            The registered tuner class.
+
+        Raises
+        ------
+        ValueError
+            If ``name`` has not been registered.
+        """
+        try:
+            return cls._REGISTRY[name]
+        except KeyError as e:  # pragma: no cover - user facing
+            available = ", ".join(sorted(cls._REGISTRY))
+            raise ValueError(
+                f"Unknown tuner '{name}'. Available tuners: {available}"
+            ) from e


### PR DESCRIPTION
## Summary
- add a registry for hyperparameter tuner classes
- register available tuners on import
- use the registry in `train.py` to look up and run tuners

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5fab2233483288c152cf63e025de4