### PR TITLE
Add unified hyperparameter tuning framework

### DIFF
--- a/LGHackerton/tuning/base.py
+++ b/LGHackerton/tuning/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import Any, Dict
 
 import pandas as pd
 
@@ -31,10 +32,10 @@ class HyperparameterTuner(ABC):
         self.model_name = getattr(cfg, "model_name", self.__class__.__name__)
         self.artifact_dir: Path = ARTIFACTS_DIR / self.model_name
         self.artifact_dir.mkdir(parents=True, exist_ok=True)
-        self._best_params: dict | None = None
+        self._best_params: Dict[str, Any] | None = None
 
     @abstractmethod
-    def run(self, n_trials: int, force: bool) -> dict:
+    def run(self, n_trials: int, force: bool) -> Dict[str, Any]:
         """Execute a hyperparameter search strategy.
 
         Implementations should perform the optimisation (e.g., via Optuna) and
@@ -52,11 +53,11 @@ class HyperparameterTuner(ABC):
 
         Returns
         -------
-        dict
+        Dict[str, Any]
             Best hyperparameter set discovered during the search.
         """
 
-    def best_params(self) -> dict:
+    def best_params(self) -> Dict[str, Any]:
         """Return and persist the best hyperparameter dictionary.
 
         The parameters are written to ``best_params.json`` inside
@@ -64,7 +65,7 @@ class HyperparameterTuner(ABC):
 
         Returns
         -------
-        dict
+        Dict[str, Any]
             The best hyperparameters from the last :meth:`run` execution.
 
         Raises
@@ -81,7 +82,7 @@ class HyperparameterTuner(ABC):
         return self._best_params
 
     @abstractmethod
-    def validate_params(self, params: dict) -> None:
+    def validate_params(self, params: Dict[str, Any]) -> None:
         """Validate a candidate hyperparameter configuration.
 
         Parameters

--- a/LGHackerton/tuning/tft.py
+++ b/LGHackerton/tuning/tft.py
@@ -94,10 +94,18 @@ class TFTTuner(HyperparameterTuner):
         _chk_int("max_epochs", s.max_epochs)
         _chk_int("patience", s.patience)
 
-    def run(self, n_trials: int, force: bool = False) -> dict:  # type: ignore[override]
+    def run(self, n_trials: int, force: bool) -> dict:  # type: ignore[override]
         if TFTTrainer is None or TFTParams is None:
             raise RuntimeError("TFTTrainer not available")
         X, y, series_ids, label_dates = self.prepare_dataset()
+        if not force:
+            cache = self.artifact_dir / "best_params.json"
+            if cache.exists():
+                with cache.open("r", encoding="utf-8") as f:
+                    cached = json.load(f)
+                self.validate_params(cached)
+                self._best_params = cached
+                return cached
         study = optuna.create_study(direction="minimize")
         search = self.search_space
 
@@ -146,8 +154,4 @@ class TFTTuner(HyperparameterTuner):
         params = TFTParams(**best)
         self._best_params = asdict(params)
         self.validate_params(self._best_params)
-        out_path = ARTIFACTS_DIR / self.model_name / "best_params.json"
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        with out_path.open("w", encoding="utf-8") as f:
-            json.dump(self._best_params, f, ensure_ascii=False, indent=2)
-        return self._best_params
+        return self.best_params()

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -30,3 +30,51 @@ Tuners validate their inputs:
 
 Tuning results are cached under the artifacts directory. Use `--force-tune` to
 recompute parameters even when cached results exist.
+
+## Default Search Spaces
+
+Each tuner exposes a dataclass describing the search space explored by Optuna.
+The following tables list the default ranges or choices used during tuning.
+
+### PatchTST
+
+| Parameter | Range/Choices |
+|-----------|---------------|
+| `d_model` | 64, 128, 256 |
+| `n_heads` | 4, 8 |
+| `depth` | 2–6 |
+| `patch_len`/`stride` | 8, 12, 14, 16, 24 |
+| `dropout` | 0.0–0.5 |
+| `lr` | 1e-4–1e-2 (log) |
+| `weight_decay` | 1e-6–1e-3 (log) |
+| `id_embed_dim` | 0, 16 |
+| `batch_size` | 64, 128, 256 |
+| `max_epochs` | 50–200 |
+| `patience` | 5–30 |
+
+### LightGBM
+
+| Parameter | Range/Choices |
+|-----------|---------------|
+| `num_leaves` | 31–255 |
+| `max_depth` | 3–16 |
+| `learning_rate` | 1e-3–0.3 (log) |
+| `subsample` | 0.5–1.0 |
+| `colsample_bytree` | 0.5–1.0 |
+| `min_data_in_leaf` | 10–200 |
+| `reg_alpha` | 1e-8–1.0 (log) |
+| `reg_lambda` | 1e-8–1.0 (log) |
+| `n_estimators` | 500–4000 |
+
+### Temporal Fusion Transformer
+
+| Parameter | Range/Choices |
+|-----------|---------------|
+| `hidden_size` | 64–512 |
+| `lstm_layers` | 1–4 |
+| `dropout` | 0.0–0.5 |
+| `attention_heads` | 1–8 |
+| `learning_rate` | 1e-4–1e-2 (log) |
+| `batch_size` | 32–256 |
+| `max_epochs` | 50–200 |
+| `patience` | 5–30 |


### PR DESCRIPTION
## Summary
- define typed `HyperparameterTuner` base with persistence helpers
- implement Optuna-based tuners for PatchTST, LightGBM and TFT models
- document default search spaces and usage in tuning guide

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60c8c9d1c832899b5096cc189949e