### PR TITLE
Refactor training pipeline with shared context

### DIFF
--- a/LGHackerton/models/patchtst/trainer.py
+++ b/LGHackerton/models/patchtst/trainer.py
@@ -16,6 +16,8 @@ except Exception as _e:
 
 from LGHackerton.models.base_trainer import BaseModel, TrainConfig
 from LGHackerton.utils.metrics import smape, weighted_smape_np, PRIORITY_OUTLETS
+from LGHackerton.preprocess import Preprocessor, H
+from LGHackerton.preprocess.preprocess_pipeline_v1_1 import SampleWindowizer
 from .train import build_loss
 
 @dataclass
@@ -311,6 +313,12 @@ class PatchTSTTrainer(BaseModel):
                     warnings.warn(
                         f"ROCV callback {getattr(cb, '__name__', repr(cb))} failed: {exc}"
                     )
+
+    @staticmethod
+    def build_dataset(pp: Preprocessor, df_full: pd.DataFrame, input_len: int | None = None):
+        if input_len is not None:
+            pp.windowizer = SampleWindowizer(lookback=input_len, horizon=H)
+        return pp.build_patch_train(df_full)
 
     def __init__(self, params: PatchTSTParams, L:int, H:int, model_dir: str, device: str):
         super().__init__(model_params=asdict(params), model_dir=model_dir)

--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -8,11 +8,10 @@ import warnings
 from pathlib import Path
 import pandas as pd
 import numpy as np
-from dataclasses import asdict
+from dataclasses import dataclass, asdict
 from datetime import datetime
 
 from LGHackerton.preprocess import Preprocessor, L, H
-from LGHackerton.preprocess.preprocess_pipeline_v1_1 import SampleWindowizer
 from LGHackerton.models.base_trainer import TrainConfig
 from LGHackerton.models.patchtst.trainer import PatchTSTTrainer, TORCH_OK
 from LGHackerton.models import ModelRegistry
@@ -37,6 +36,19 @@ from LGHackerton.config.default import (
 )
 from LGHackerton.tuning import TunerRegistry
 from LGHackerton.utils.seed import set_seed
+
+
+@dataclass
+class PipelineContext:
+    preprocessor: Preprocessor | None = None
+    df_full: pd.DataFrame | None = None
+    cfg: TrainConfig | None = None
+    params: dict | None = None
+    input_len: int | None = None
+    device: str | None = None
+    model_name: str | None = None
+    show_progress: bool = SHOW_PROGRESS
+    oof_df: pd.DataFrame | None = None
 
 
 def _log_fold_start(seed: int, fold_idx: int, tr_mask: np.ndarray, va_mask: np.ndarray, cfg: TrainConfig, prefix: str) -> None:
@@ -179,94 +191,80 @@ def report_oof_metrics(oof_df, model_name: str) -> None:
         logging.info("%s %s: %s", model_name, name, value)
 
 
-def run_preprocess(show_progress: bool) -> tuple[Preprocessor, pd.DataFrame]:
-    """Run preprocessing and return the fitted preprocessor and full dataframe."""
+def run_preprocess(ctx: PipelineContext) -> None:
+    """Run preprocessing and store artifacts in the context."""
     df_train_raw = _read_table(TRAIN_PATH)
-    pp = Preprocessor(show_progress=show_progress)
+    pp = Preprocessor(show_progress=ctx.show_progress)
     df_full = pp.fit_transform_train(df_train_raw)
     pp.save(ARTIFACTS_PATH)
-    return pp, df_full
+    ctx.preprocessor = pp
+    ctx.df_full = df_full
 
 
-def run_tuning(
-    model_name: str,
-    pp: Preprocessor,
-    df_full: pd.DataFrame,
-    cfg: TrainConfig,
-    patch_params: dict,
-    patch_input_len: int | None,
-    skip_tune: bool,
-    force_tune: bool,
-) -> tuple[dict, int | None]:
-    """Optionally run hyperparameter tuning and update PatchTST params."""
+def run_tuning(ctx: PipelineContext, skip_tune: bool, force_tune: bool) -> None:
+    """Optionally run hyperparameter tuning and update context parameters."""
     if skip_tune:
-        return patch_params, patch_input_len
+        return
     try:
-        tuner_cls = TunerRegistry.get(model_name)
+        tuner_cls = TunerRegistry.get(ctx.model_name)
     except ValueError:  # pragma: no cover - user facing
         logging.warning("Unknown tuner for model")
-        return patch_params, patch_input_len
-    tuner = tuner_cls(pp, df_full, cfg)
-    tuned = tuner.run(n_trials=cfg.n_trials, force=force_tune)
-    patch_input_len = tuned.pop("input_len", patch_input_len)
-    patch_params.update(tuned)
-    return patch_params, patch_input_len
+        return
+    tuner = tuner_cls(ctx.preprocessor, ctx.df_full, ctx.cfg)
+    tuned = tuner.run(n_trials=ctx.cfg.n_trials, force=force_tune)
+    ctx.input_len = tuned.pop("input_len", ctx.input_len)
+    ctx.params.update(tuned)
 
 
-def run_training(
-    trainer_cls,
-    pp: Preprocessor,
-    df_full: pd.DataFrame,
-    cfg: TrainConfig,
-    patch_params: dict,
-    patch_input_len: int | None,
-    device: str,
-) -> pd.DataFrame:
-    """Train model and return out-of-fold predictions."""
-    if patch_input_len is not None:
-        pp.windowizer = SampleWindowizer(lookback=patch_input_len, horizon=H)
-    X_train, y_train, series_ids, label_dates = pp.build_patch_train(df_full)
-    if not TORCH_OK:
+def run_training(ctx: PipelineContext) -> None:
+    """Train model and store OOF predictions in the context."""
+    trainer_cls = ModelRegistry.get(ctx.model_name)
+    X_train, y_train, series_ids, label_dates = trainer_cls.build_dataset(
+        ctx.preprocessor, ctx.df_full, ctx.input_len
+    )
+    if ctx.model_name == "patchtst" and not TORCH_OK:
         raise RuntimeError("PyTorch is not available")
-    patch_params.pop("input_len", None)
     params_module = importlib.import_module(trainer_cls.__module__)
     params_cls_name = trainer_cls.__name__.replace("Trainer", "Params")
     params_cls = getattr(params_module, params_cls_name)
-    patch_params_obj = params_cls(**patch_params)
-    L_used = patch_input_len if patch_input_len is not None else L
-    trainer = trainer_cls(params=patch_params_obj, L=L_used, H=H, model_dir=cfg.model_dir, device=device)
-    trainer.train(X_train, y_train, series_ids, label_dates, cfg)
-    return trainer.get_oof()
+    params_obj = params_cls(**ctx.params)
+    init_kwargs = {"params": params_obj, "model_dir": ctx.cfg.model_dir, "device": ctx.device}
+    if ctx.model_name == "patchtst":
+        L_used = ctx.input_len if ctx.input_len is not None else L
+        init_kwargs.update({"L": L_used, "H": H})
+    trainer = trainer_cls(**init_kwargs)
+    trainer.train(X_train, y_train, series_ids, label_dates, ctx.cfg)
+    ctx.oof_df = trainer.get_oof()
 
 
-def run_oof_prediction(oof_df: pd.DataFrame, model_name: str) -> None:
+def run_oof_prediction(ctx: PipelineContext) -> None:
     """Persist OOF predictions and diagnostics."""
-    oof_df.to_csv(OOF_PATCH_OUT, index=False)
-    report_oof_metrics(oof_df, model_name)
+    ctx.oof_df.to_csv(OOF_PATCH_OUT, index=False)
+    report_oof_metrics(ctx.oof_df, ctx.model_name)
 
-    # diagnostics for PatchTST and similar models
-    try:
-        res_p = oof_df["y"] - oof_df["yhat"]
-        diag_dir = ARTIFACTS_DIR / "diagnostics" / model_name / "oof"
-        diag_dir.mkdir(parents=True, exist_ok=True)
-        acf_df = compute_acf(res_p)
-        pacf_df = compute_pacf(res_p)
-        lb_df, res_used = ljung_box_test(res_p, lags=[10, 20, 30], return_residuals=True)
-        wt_df = white_test(res_p)
-        acf_df.to_csv(diag_dir / "acf.csv", index=False)
-        pacf_df.to_csv(diag_dir / "pacf.csv", index=False)
-        lb_df.to_csv(diag_dir / "ljung_box.csv", index=False)
-        res_used.rename("residual").to_csv(diag_dir / "ljung_box_input.csv", index=False)
-        wt_df.to_csv(diag_dir / "white_test.csv", index=False)
-        plot_residuals(res_p, diag_dir)
-        logging.info("%s Ljung-Box p-values: %s", model_name, lb_df["pvalue"].tolist())
-        logging.info("%s Ljung-Box residual sample: %s", model_name, res_used.head().tolist())
-        logging.info("%s White test p-value: %s", model_name, wt_df["lm_pvalue"].iloc[0])
-    except Exception as e:  # pragma: no cover - best effort
-        logging.warning("%s diagnostics failed: %s", model_name, e)
+    if ctx.model_name == "patchtst":
+        try:
+            res_p = ctx.oof_df["y"] - ctx.oof_df["yhat"]
+            diag_dir = ARTIFACTS_DIR / "diagnostics" / ctx.model_name / "oof"
+            diag_dir.mkdir(parents=True, exist_ok=True)
+            acf_df = compute_acf(res_p)
+            pacf_df = compute_pacf(res_p)
+            lb_df, res_used = ljung_box_test(res_p, lags=[10, 20, 30], return_residuals=True)
+            wt_df = white_test(res_p)
+            acf_df.to_csv(diag_dir / "acf.csv", index=False)
+            pacf_df.to_csv(diag_dir / "pacf.csv", index=False)
+            lb_df.to_csv(diag_dir / "ljung_box.csv", index=False)
+            res_used.rename("residual").to_csv(diag_dir / "ljung_box_input.csv", index=False)
+            wt_df.to_csv(diag_dir / "white_test.csv", index=False)
+            plot_residuals(res_p, diag_dir)
+            logging.info("%s Ljung-Box p-values: %s", ctx.model_name, lb_df["pvalue"].tolist())
+            logging.info("%s Ljung-Box residual sample: %s", ctx.model_name, res_used.head().tolist())
+            logging.info("%s White test p-value: %s", ctx.model_name, wt_df["lm_pvalue"].iloc[0])
+        except Exception as e:  # pragma: no cover - best effort
+            logging.warning("%s diagnostics failed: %s", ctx.model_name, e)
 
 
-def main(show_progress: bool | None = None):
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--progress", dest="show_progress", action="store_true", help="show preprocessing progress")
     parser.add_argument("--no-progress", dest="show_progress", action="store_false", help="hide preprocessing progress")
@@ -283,14 +281,10 @@ def main(show_progress: bool | None = None):
         trainer_cls = ModelRegistry.get(args.model)
     except KeyError as e:
         parser.error(str(e))
-    if show_progress is None:
-        show_progress = args.show_progress
 
     device = select_device()  # ask user for compute environment
 
-    pp, df_full = run_preprocess(show_progress)
-
-    patch_params_dict, patch_input_len = load_best_patch_params()
+    params_dict, input_len = load_best_patch_params()
     cfg = TrainConfig(**TRAIN_CFG)
     cfg.n_trials = args.trials
     cfg.timeout = args.timeout
@@ -298,14 +292,35 @@ def main(show_progress: bool | None = None):
         _patch_patchtst_logging(cfg)
     set_seed(cfg.seed)
 
-    patch_params_dict, patch_input_len = run_tuning(
-        args.model, pp, df_full, cfg, patch_params_dict, patch_input_len, args.skip_tune, args.force_tune
+    ctx = PipelineContext(
+        cfg=cfg,
+        params=params_dict,
+        input_len=input_len,
+        device=device,
+        model_name=args.model,
+        show_progress=args.show_progress,
     )
 
-    oof_df = run_training(
-        trainer_cls, pp, df_full, cfg, patch_params_dict, patch_input_len, device
-    )
-    run_oof_prediction(oof_df, args.model)
+    try:
+        run_preprocess(ctx)
+    except (ValueError, RuntimeError) as e:
+        logging.error("Preprocessing failed: %s", e)
+        return
+    try:
+        run_tuning(ctx, args.skip_tune, args.force_tune)
+    except (ValueError, RuntimeError) as e:
+        logging.error("Tuning failed: %s", e)
+        return
+    try:
+        run_training(ctx)
+    except (ValueError, RuntimeError) as e:
+        logging.error("Training failed: %s", e)
+        return
+    try:
+        run_oof_prediction(ctx)
+    except (ValueError, RuntimeError) as e:
+        logging.error("Prediction failed: %s", e)
+        return
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Introduce `PipelineContext` dataclass to share state across preprocessing, tuning, training and prediction steps
- Add `build_dataset` to PatchTST trainer and refactor train script to use model registry and context-driven stages
- Gate diagnostics on model name and streamline CLI-driven pipeline execution

## Testing
- `pytest tests/test_pipeline_patchtst.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a65455fe9c832893ce32bde4a23025