### PR TITLE
Document model and tuner registries

### DIFF
--- a/LGHackerton/models/registry.py
+++ b/LGHackerton/models/registry.py
@@ -17,7 +17,9 @@ class ModelRegistry:
             return cls._REGISTRY[name]
         except KeyError as e:  # pragma: no cover - user facing
             available = ", ".join(sorted(cls._REGISTRY))
-            raise KeyError(f"Unknown model '{name}'. Available models: {available}") from e
+            raise ValueError(
+                f"Unknown model '{name}'. Available models: {available}"
+            ) from e
 
     @classmethod
     def available(cls):

--- a/LGHackerton/predict.py
+++ b/LGHackerton/predict.py
@@ -38,7 +38,7 @@ def main():
     args = parser.parse_args()
     try:
         trainer_cls = ModelRegistry.get(args.model)
-    except KeyError as e:
+    except ValueError as e:
         parser.error(str(e))
 
     device = select_device()

--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -279,7 +279,7 @@ def main():
     args = parser.parse_args()
     try:
         trainer_cls = ModelRegistry.get(args.model)
-    except KeyError as e:
+    except ValueError as e:
         parser.error(str(e))
 
     device = select_device()  # ask user for compute environment

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ python LGHackerton/tune.py --task patchtst_grid --config configs/patchtst.yaml
 
 This avoids confusion when both grid-search and Optuna artifacts may exist.
 
+## Model and Tuner Registry
+
+Training scripts resolve trainer classes and Optuna-based tuners through
+lightweight registries. Providing an unknown name raises a `ValueError` listing
+available options. See [docs/registry_tuner.md](docs/registry_tuner.md) for full
+usage and error-handling rules.
+
 ## Combining Predictions
 
 After generating predictions from different models, use the postprocessing
@@ -66,4 +73,10 @@ PY
 
 The helper functions `aggregate_predictions` and `convert_to_submission` ensure
 consistent formatting and handle any missing or duplicate entries.
+
+## Documentation
+
+- [Callbacks](docs/callbacks.md)
+- [Hyperparameter Tuning](docs/tuning.md)
+- [Model & Tuner Registries](docs/registry_tuner.md)
 

--- a/docs/registry_tuner.md
+++ b/docs/registry_tuner.md
@@ -1,0 +1,76 @@
+# Model and Tuner Registries
+
+## ModelRegistry (`LGHackerton/models/registry.py`)
+
+```python
+from LGHackerton.models import ModelRegistry
+trainer_cls = ModelRegistry.get("lgbm")
+model = trainer_cls(cfg)
+```
+
+Requesting an unregistered model raises `ValueError: Unknown model '<name>'. Available models: ...`.
+`train.py` and `predict.py` convert this into an `argparse` error so users
+receive a concise message.
+
+## TunerRegistry and HyperparameterTuner (`LGHackerton/tuning/registry.py`, `LGHackerton/tuning/base.py`)
+
+`TunerRegistry.get(name)` returns a class implementing the
+`HyperparameterTuner` interface.
+
+| Method | Returns | Exceptions |
+|-------|---------|------------|
+| `run(n_trials, force)` | dict of best parameters | propagates `TypeError`/`ValueError` from `validate_params`; may raise `RuntimeError` for missing dependencies |
+| `best_params()` | dict written to `best_params.json` | `RuntimeError` if `run` has not executed |
+| `validate_params(params)` | `None` | `TypeError` for missing fields, `ValueError` for out-of-range values |
+
+### CLI usage
+
+```bash
+python LGHackerton/train.py --model lgbm --trials 30
+```
+
+### Examples
+
+```python
+from LGHackerton.tuning.lgbm import LGBMTuner
+lgbm_tuner = LGBMTuner(pp, df, cfg)
+lgbm_tuner.run(n_trials=30, force=False)
+```
+
+```python
+from LGHackerton.tuning.tft import TFTTuner
+tft_tuner = TFTTuner(pp, df, cfg)
+tft_tuner.run(n_trials=50, force=True)
+```
+
+Parameter validation failures in these tuners raise `TypeError` when required
+fields are missing and `ValueError` when a value lies outside the allowed
+range.
+
+## Exception handling
+
+- Unregistered model → `ValueError`
+- Parameter validation failure → `TypeError`/`ValueError`
+
+In `train.py`, preprocessing, tuning, and training failures are logged via
+`logging.error` and halt the run. Unknown models surface through `parser.error`
+messages. `predict.py` mirrors this behaviour when resolving trainers.
+
+## Pipeline flow
+
+```mermaid
+flowchart LR
+    A[Data] --> B[Preprocessing]
+    B --> C[Model Selection]
+    C --> D[Tuner Selection]
+    D --> E[Training/Predict]
+    E --> F[Postprocessing]
+```
+
+## Regression tests
+
+Verify the PatchTST pipeline remains intact:
+
+```bash
+pytest tests/test_pipeline_patchtst.py
+```


### PR DESCRIPTION
## Summary
- Raise `ValueError` for unknown models and catch it in CLI helpers
- Add `docs/registry_tuner.md` describing ModelRegistry, TunerRegistry, and error rules
- Link new documentation from README

## Testing
- `pytest tests/test_pipeline_patchtst.py`

------
https://chatgpt.com/codex/tasks/task_e_68a65e23a58c8328aff28e5ad60e8b91