### PR TITLE
Generalize prediction pipeline for trainer-specific parameters

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -27,8 +27,8 @@ ARTIFACTS_PATH  = str((ARTIFACTS_DIR / "preprocess_artifacts.pkl").resolve())
 SUBMISSION_OUT  = str((ARTIFACTS_DIR / "submission.csv").resolve())
 # PatchTST는 prefix를 요구하므로 확장자 없이 파일명만 제공
 PATCH_EVAL_OUT  = str((ARTIFACTS_DIR / "patch_eval").resolve())
-# PatchTST 예측 결과 저장 경로
-PATCH_PRED_OUT  = str((ARTIFACTS_DIR / "eval_patch.csv").resolve())
+# 모델 예측 결과 저장 경로
+PRED_OUT  = str((ARTIFACTS_DIR / "eval_pred.csv").resolve())
 OOF_PATCH_OUT = str((ARTIFACTS_DIR / "oof_patch.csv").resolve())
 
 # preprocessing options

--- a/LGHackerton/models/patchtst/trainer.py
+++ b/LGHackerton/models/patchtst/trainer.py
@@ -264,6 +264,9 @@ class PatchTSTTrainer(BaseModel):
     fold index and corresponding train/validation masks. Errors raised inside
     callbacks are isolated from training by being converted to warnings.
     """
+    #: column suffix used for prediction outputs
+    prediction_column_name = "patch"
+
     #: Callbacks executed for each ROCV fold immediately after slices are
     #: computed and before training begins. Each callback must accept
     #: ``(seed, fold_idx, train_mask, val_mask, cfg)``. Exceptions are caught
@@ -319,6 +322,11 @@ class PatchTSTTrainer(BaseModel):
         if input_len is not None:
             pp.windowizer = SampleWindowizer(lookback=input_len, horizon=H)
         return pp.build_patch_train(df_full)
+
+    @staticmethod
+    def build_eval_dataset(pp: Preprocessor, df_full: pd.DataFrame):
+        """Build evaluation dataset for prediction."""
+        return pp.build_patch_eval(df_full)
 
     def __init__(self, params: PatchTSTParams, L:int, H:int, model_dir: str, device: str):
         super().__init__(model_params=asdict(params), model_dir=model_dir)

--- a/LGHackerton/predict.py
+++ b/LGHackerton/predict.py
@@ -10,12 +10,11 @@ import argparse
 
 from LGHackerton.preprocess import Preprocessor, L, H
 from LGHackerton.models import ModelRegistry
-from LGHackerton.models.patchtst.trainer import PatchTSTParams
 from LGHackerton.utils.device import select_device
 from LGHackerton.config.default import (
     TEST_GLOB,
     ARTIFACTS_PATH,
-    PATCH_PRED_OUT,
+    PRED_OUT,
     SUBMISSION_OUT,
     PATCH_PARAMS,
     TRAIN_CFG,
@@ -23,6 +22,7 @@ from LGHackerton.config.default import (
 from LGHackerton.utils.seed import set_seed
 from src.data.preprocess import inverse_symmetric_transform
 from LGHackerton.postprocess import aggregate_predictions, convert_to_submission
+import importlib, inspect
 
 def _read_table(path: str) -> pd.DataFrame:
     if path.lower().endswith(".csv"):
@@ -55,40 +55,51 @@ def main():
     cfg = TrainConfig(**TRAIN_CFG)
     set_seed(cfg.seed)
 
-    pt = trainer_cls(params=PatchTSTParams(**PATCH_PARAMS), L=L, H=H, model_dir=cfg.model_dir, device=device)
+    module = importlib.import_module(trainer_cls.__module__)
+    params_cls = None
+    for name, obj in inspect.getmembers(module, inspect.isclass):
+        if name.endswith("Params"):
+            params_cls = obj
+            break
+    if params_cls is None:
+        raise RuntimeError(f"No Params dataclass found in {module.__name__}")
+
+    params = params_cls(**PATCH_PARAMS)
+    pt = trainer_cls(params=params, L=L, H=H, model_dir=cfg.model_dir, device=device)
     pt.load(os.path.join(cfg.model_dir, f"{model_name}.pt"))
 
     model_outputs = []
 
-    patch_outputs = []
+    single_outputs = []
+    col_suffix = getattr(trainer_cls, "prediction_column_name", model_name)
+    y_col = f"yhat_{col_suffix}"
     for path in sorted(glob.glob(TEST_GLOB)):
         df_eval_raw = _read_table(path)
         df_eval_full = pp.transform_eval(df_eval_raw)
 
-        X_eval, sids, _ = pp.build_patch_eval(df_eval_full)
+        X_eval, sids, _ = trainer_cls.build_eval_dataset(pp, df_eval_full)
         sid_idx = np.array([pt.id2idx.get(sid, 0) for sid in sids])
-        y_patch = pt.predict(X_eval, sid_idx)
+        y_pred = pt.predict(X_eval, sid_idx)
         reps = np.repeat(sids, H)
         hs = np.tile(np.arange(1, H + 1), len(sids))
-        out = pd.DataFrame({"series_id": reps, "h": hs, "yhat_patch": y_patch.reshape(-1)})
+        out = pd.DataFrame({"series_id": reps, "h": hs, y_col: y_pred.reshape(-1)})
 
-        out["yhat_patch"] = inverse_symmetric_transform(out["yhat_patch"].values)
+        out[y_col] = inverse_symmetric_transform(out[y_col].values)
 
         prefix = re.search(r"(TEST_\d+)", os.path.basename(path)).group(1)
         out["test_id"] = prefix
         out["date"] = out["h"].map(lambda h: f"{prefix}+{h}일")
-        patch_outputs.append(out)
+        single_outputs.append(out)
 
-    # Combine outputs from all test files for the PatchTST model
-    patch_df = pd.concat(patch_outputs, ignore_index=True)
-    model_outputs.append(patch_df)
+    pred_df = pd.concat(single_outputs, ignore_index=True)
+    model_outputs.append(pred_df)
 
     # Example: to ensemble another model, append its dataframe here.
     # lgbm_df = pd.read_csv("artifacts/eval_lgbm.csv")
     # model_outputs.append(lgbm_df)
 
-    os.makedirs(os.path.dirname(PATCH_PRED_OUT), exist_ok=True)
-    patch_df.to_csv(PATCH_PRED_OUT, index=False, encoding="utf-8-sig")
+    os.makedirs(os.path.dirname(PRED_OUT), exist_ok=True)
+    pred_df.to_csv(PRED_OUT, index=False, encoding="utf-8-sig")
 
     all_pred = aggregate_predictions(model_outputs)
     submission_df = convert_to_submission(all_pred)


### PR DESCRIPTION
## Summary
- Dynamically discover model parameter dataclasses and build evaluation datasets via trainer
- Add generic prediction column naming and output path for model predictions
- Expose trainer-provided eval dataset builder and column suffix for PatchTST

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6679710d08328ad7064a445a27701