### PR TITLE
feat: centralize table reading across scripts

### DIFF
--- a/LGHackerton/predict.py
+++ b/LGHackerton/predict.py
@@ -22,14 +22,8 @@ from LGHackerton.config.default import (
 from LGHackerton.utils.seed import set_seed
 from src.data.preprocess import inverse_symmetric_transform
 from LGHackerton.postprocess import aggregate_predictions, convert_to_submission
+from LGHackerton.utils.io import read_table
 import importlib, inspect
-
-def _read_table(path: str) -> pd.DataFrame:
-    if path.lower().endswith(".csv"):
-        return pd.read_csv(path, encoding="utf-8-sig")
-    if path.lower().endswith((".xls", ".xlsx")):
-        return pd.read_excel(path)
-    raise ValueError("Unsupported file type. Use .csv or .xlsx")
 
 
 def main():
@@ -74,7 +68,7 @@ def main():
     col_suffix = getattr(trainer_cls, "prediction_column_name", model_name)
     y_col = f"yhat_{col_suffix}"
     for path in sorted(glob.glob(TEST_GLOB)):
-        df_eval_raw = _read_table(path)
+        df_eval_raw = read_table(path)
         df_eval_full = pp.transform_eval(df_eval_raw)
 
         X_eval, sids, _ = trainer_cls.build_eval_dataset(pp, df_eval_full)

--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -23,6 +23,7 @@ from LGHackerton.utils.diagnostics import (
     plot_residuals,
 )
 from LGHackerton.utils.metrics import compute_oof_metrics
+from LGHackerton.utils.io import read_table
 from LGHackerton.config.default import (
     TRAIN_PATH,
     ARTIFACTS_PATH,
@@ -115,13 +116,6 @@ def _patch_patchtst_logging(cfg: TrainConfig) -> None:
             "No PatchTST fold logging hooks found; fold information will not be logged",
             stacklevel=2,
         )
-
-def _read_table(path: str) -> pd.DataFrame:
-    if path.lower().endswith(".csv"):
-        return pd.read_csv(path)
-    if path.lower().endswith((".xls", ".xlsx")):
-        return pd.read_excel(path)
-    raise ValueError("Unsupported file type. Use .csv or .xlsx")
 
 
 def _load_patchtst_params() -> tuple[dict, int | None]:
@@ -217,7 +211,7 @@ def report_oof_metrics(oof_df, model_name: str) -> None:
 
 def run_preprocess(ctx: PipelineContext) -> None:
     """Run preprocessing and store artifacts in the context."""
-    df_train_raw = _read_table(TRAIN_PATH)
+    df_train_raw = read_table(TRAIN_PATH)
     pp = Preprocessor(show_progress=ctx.show_progress)
     df_full = pp.fit_transform_train(df_train_raw)
     pp.save(ARTIFACTS_PATH)

--- a/LGHackerton/utils/io.py
+++ b/LGHackerton/utils/io.py
@@ -1,0 +1,62 @@
+"""Input/output helper utilities.
+
+This module centralizes basic table-loading logic used across the
+project. It exposes :func:`read_table` which can handle both CSV and
+Excel files, automatically selecting the appropriate pandas reader based
+on the file extension. The underlying implementation lives in the
+private :func:`_read_table` helper to allow reuse inside the package
+without polluting the public API with the underscore-prefixed function.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+
+def _read_table(path: str, **kwargs: Any) -> pd.DataFrame:
+    """Read a CSV or Excel file into a :class:`~pandas.DataFrame`.
+
+    Parameters
+    ----------
+    path : str
+        Path to the input file. Supported extensions are ``.csv``,
+        ``.xls`` and ``.xlsx``.
+    **kwargs : Any
+        Additional keyword arguments passed to the underlying pandas
+        reader.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Parsed dataframe containing the file's contents.
+
+    Raises
+    ------
+    ValueError
+        If the file extension is not one of the supported types.
+    """
+
+    lower = path.lower()
+    if lower.endswith(".csv"):
+        # ``utf-8-sig`` gracefully handles files with or without BOM.
+        return pd.read_csv(path, encoding="utf-8-sig", **kwargs)
+    if lower.endswith((".xls", ".xlsx")):
+        return pd.read_excel(path, **kwargs)
+    raise ValueError("Unsupported file type. Use .csv or .xlsx")
+
+
+def read_table(path: str, **kwargs: Any) -> pd.DataFrame:
+    """Public wrapper around :func:`_read_table`.
+
+    This helper simply forwards all arguments to the private
+    implementation. It mirrors pandas' behaviour while constraining the
+    file formats we support within the project.
+    """
+
+    return _read_table(path, **kwargs)
+
+
+__all__ = ["read_table"]
+


### PR DESCRIPTION
## Summary
- add io helper with `_read_table` for CSV/Excel
- replace local helpers in training and prediction with shared `read_table`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a66eb9208c8328ad5a5603d460850b