### PR TITLE
Refactor params loading and streamline prediction interface

### DIFF
--- a/LGHackerton/models/base_trainer.py
+++ b/LGHackerton/models/base_trainer.py
@@ -43,3 +43,12 @@ class BaseModel(ABC):
 
     @abstractmethod
     def load(self, *args, **kwargs) -> None: ...
+
+    @staticmethod
+    @abstractmethod
+    def build_eval_dataset(pp, df_eval_full):
+        """Build evaluation dataset for prediction."""
+
+    @abstractmethod
+    def predict_df(self, eval_df):
+        """Generate prediction dataframe from evaluation dataset."""

--- a/LGHackerton/models/lgbm_trainer.py
+++ b/LGHackerton/models/lgbm_trainer.py
@@ -73,6 +73,11 @@ class LGBMTrainer(BaseModel):
         return df_train, y, series_ids, label_dates
 
     @staticmethod
+    def build_eval_dataset(pp: Preprocessor, df_full: pd.DataFrame):
+        """Build evaluation dataset for prediction."""
+        return pp.build_lgbm_eval(df_full)
+
+    @staticmethod
     def _compute_label_date(df: pd.DataFrame, date_col: str, h_col: str) -> pd.Series:
         return pd.to_datetime(df[date_col]) + pd.to_timedelta(df[h_col].astype(int), unit="D")
 
@@ -436,6 +441,10 @@ class LGBMTrainer(BaseModel):
         out = dfe[["series_id", "h"]].copy()
         out["yhat_lgbm"] = preds
         return out
+
+    def predict_df(self, eval_df: pd.DataFrame) -> pd.DataFrame:
+        """Predict and return a dataframe with LightGBM forecasts."""
+        return self.predict(eval_df)
 
     def get_oof(self) -> pd.DataFrame:
         return pd.DataFrame(self.oof_records)

--- a/LGHackerton/utils/params.py
+++ b/LGHackerton/utils/params.py
@@ -1,0 +1,77 @@
+import json
+import logging
+from pathlib import Path
+from typing import Tuple
+
+import pandas as pd
+
+from LGHackerton.config.default import PATCH_PARAMS, ARTIFACTS_DIR, OPTUNA_DIR
+
+
+def _load_patchtst_params() -> Tuple[dict, int | None]:
+    """Load PatchTST parameters from tuning artifacts.
+
+    Preference order:
+    1. Grid search results saved in ``artifacts/patchtst_search.csv``. The
+       combination with the lowest ``val_wsmape`` is selected and its
+       ``input_len`` is returned separately to adjust window sizing.
+    2. Optuna best parameters stored in ``OPTUNA_DIR/patchtst_best.json``. The
+       JSON may also include ``input_len`` which is returned separately.
+    3. Default ``PATCH_PARAMS`` when no artifacts are available.
+
+    Returns
+    -------
+    params : dict
+        Parameters for :class:`PatchTSTParams`.
+    input_len : int | None
+        Lookback length if provided by artifacts, otherwise ``None``.
+    """
+
+    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    search_path = ARTIFACTS_DIR / "patchtst_search.csv"
+    if search_path.exists():
+        try:
+            df = pd.read_csv(search_path)
+            if "val_wsmape" in df.columns:
+                df = df[df["val_wsmape"].notna()]
+                if not df.empty:
+                    row = df.loc[df["val_wsmape"].idxmin()]
+                    params = {
+                        **PATCH_PARAMS,
+                        "patch_len": int(row["patch_len"]),
+                        "stride": int(row["patch_len"]),
+                        "lr": float(row["lr"]),
+                        "scaler": row["scaler"],
+                    }
+                    return params, int(row["input_len"])
+        except Exception as e:  # pragma: no cover - best effort
+            logging.warning("Failed to parse %s: %s", search_path, e)
+
+    best_path = Path(OPTUNA_DIR) / "patchtst_best.json"
+    if not best_path.exists():
+        alt_path = ARTIFACTS_DIR / "patchtst" / "best_params.json"
+        if alt_path.exists():
+            best_path = alt_path
+    try:
+        with best_path.open("r", encoding="utf-8") as f:
+            patch_best = json.load(f)
+        patch_best.setdefault("stride", patch_best.get("patch_len", PATCH_PARAMS["patch_len"]))
+        input_len = patch_best.pop("input_len", None)
+        return {**PATCH_PARAMS, **patch_best}, input_len
+    except Exception as e:  # pragma: no cover - best effort
+        logging.warning("Failed to load PatchTST params from %s: %s", best_path, e)
+        return PATCH_PARAMS, None
+
+
+def load_best_params(model_name: str) -> Tuple[dict, int | None]:
+    """Dispatch to a model-specific parameter loader."""
+
+    loaders = {
+        "patchtst": _load_patchtst_params,
+    }
+    loader = loaders.get(model_name)
+    if loader is None:
+        logging.info("No specialized loader for %s; using empty parameters", model_name)
+        return {}, None
+    return loader()


### PR DESCRIPTION
## Summary
- Move parameter-loading logic to `utils/params.py`
- Expose common `build_eval_dataset` and `predict_df` interfaces on trainers
- Simplify prediction script to load model-specific params and use trainer helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a676079fac83288369f6a6c3b7cdc1