### PR TITLE
Save PatchTST meta to pt file

### DIFF
--- a/LGHackerton/models/patchtst/trainer.py
+++ b/LGHackerton/models/patchtst/trainer.py
@@ -672,13 +672,21 @@ class PatchTSTTrainer(BaseModel):
         if not TORCH_OK: return
         import torch
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        index=[]
+        index = []
         for i, m in enumerate(self.models):
             fpath = os.path.join(self.model_dir, f"patchtst_fold{i}.pt")
             torch.save(m.state_dict(), fpath)
             index.append(os.path.basename(fpath))
-        with open(path.replace(".pt",".json"),"w",encoding="utf-8") as f:
-            json.dump({"params":self.model_params,"L":self.L,"H":self.H,"index":index,"id2idx":self.id2idx},f,ensure_ascii=False,indent=2)
+        meta = {
+            "params": self.model_params,
+            "L": self.L,
+            "H": self.H,
+            "index": index,
+            "id2idx": self.id2idx,
+        }
+        with open(path.replace(".pt", ".json"), "w", encoding="utf-8") as f:
+            json.dump(meta, f, ensure_ascii=False, indent=2)
+        torch.save(meta, path)
     def load(self, path:str)->None:
         self._ensure_torch(); import torch, json, os
         meta=path.replace(".pt",".json")


### PR DESCRIPTION
## Summary
- persist PatchTST metadata to the requested `.pt` file alongside existing JSON

## Testing
- `pytest tests/test_pipeline_patchtst.py::test_pipeline_patchtst -q`
- `python - <<'PY'
from LGHackerton.models.patchtst.trainer import PatchTSTTrainer, PatchTSTParams
import os
trainer = PatchTSTTrainer(PatchTSTParams(), model_dir='LGHackerton/artifacts/models', device='cpu')
trainer.save('LGHackerton/artifacts/models/patchtst.pt')
print('exists', os.path.exists('LGHackerton/artifacts/models/patchtst.pt'))
print('json exists', os.path.exists('LGHackerton/artifacts/models/patchtst.json'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a681c558f48328ba04cbaba2a49715