### PR TITLE
Ensure PatchTST windowizer keeps guard

### DIFF
--- a/LGHackerton/models/patchtst/trainer.py
+++ b/LGHackerton/models/patchtst/trainer.py
@@ -320,7 +320,10 @@ class PatchTSTTrainer(BaseModel):
     @staticmethod
     def build_dataset(pp: Preprocessor, df_full: pd.DataFrame, input_len: int | None = None):
         if input_len is not None:
-            pp.windowizer = SampleWindowizer(lookback=input_len, horizon=H)
+            horizon = pp.windowizer.H
+            pp.windowizer = SampleWindowizer(
+                lookback=input_len, horizon=horizon, guard=pp.guard
+            )
         return pp.build_patch_train(df_full)
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Preserve preprocessor leak guard when overriding PatchTST SampleWindowizer
- Maintain horizon setting by reading it from existing windowizer

## Testing
- `PYTHONPATH=. python - <<'PY'
from LGHackerton.preprocess import Preprocessor
import pandas as pd
from LGHackerton.models.patchtst.trainer import PatchTSTTrainer
pp = Preprocessor()
df = pd.read_csv('LGHackerton/data/train.csv')
df_full = pp.fit_transform_train(df)
res = PatchTSTTrainer.build_dataset(pp, df_full, input_len=28)
print(len(res))
for arr in res:
    print(type(arr), getattr(arr, 'shape', None))
PY`
- `PYTHONPATH=. python LGHackerton/train.py --model patchtst --skip-tune --no-progress` *(interrupted after first epoch; no scope errors observed)*

------
https://chatgpt.com/codex/tasks/task_e_68a697c127708328b8062f278784c599