### PR TITLE
Validate submission columns against sample

### DIFF
--- a/LGHackerton/predict.py
+++ b/LGHackerton/predict.py
@@ -16,6 +16,7 @@ from LGHackerton.config.default import (
     PRED_OUT,
     SUBMISSION_OUT,
     TRAIN_CFG,
+    SAMPLE_SUB_PATH,
 )
 from LGHackerton.utils.seed import set_seed
 from LGHackerton.postprocess import aggregate_predictions, convert_to_submission
@@ -94,8 +95,9 @@ def main():
     if not sub_path.exists():
         raise RuntimeError("submission file missing")
     out_df = pd.read_csv(sub_path)
-    if not {"id", "y"}.issubset(out_df.columns):
-        raise RuntimeError("submission columns missing")
+    sample_cols = pd.read_csv(SAMPLE_SUB_PATH, nrows=0).columns
+    if list(out_df.columns) != list(sample_cols):
+        raise RuntimeError("submission columns mismatch")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Ensure `predict.py` verifies submission columns match `sample_submission.csv`
- Import `SAMPLE_SUB_PATH` from default config for flexible column lookup
- Update pipeline test to generate stub submission with correct columns

## Testing
- `pytest -q`
- `PYTHONPATH=. python LGHackerton/predict.py` *(fails: No module named 'preprocess_pipeline_v1_1')*


------
https://chatgpt.com/codex/tasks/task_e_68a6b18247b88328af03c24242d81a7e