### PR TITLE
feat: extend PatchTST parameters

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -41,6 +41,7 @@ PATCH_PARAMS = dict(
     id_embed_dim=16,
     lr=1e-3, weight_decay=1e-4, batch_size=256,
     max_epochs=200, patience=20,
+    kappa=1.0, epsilon_leaky=1e-8,
     num_workers=0,
 )
 TRAIN_CFG = dict(

--- a/LGHackerton/models/patchtst/trainer.py
+++ b/LGHackerton/models/patchtst/trainer.py
@@ -55,6 +55,14 @@ class PatchTSTParams:
         Maximum number of training epochs per fold.
     patience : int
         Early stopping patience measured in epochs.
+    loss : str
+        Loss function to use during optimisation.
+    loss_alpha : float
+        Mixing factor when ``loss`` is ``"hybrid"``.
+    kappa : float
+        Scaling factor applied within the loss function.
+    epsilon_leaky : float
+        Small constant added for numerical stability in leaky operations.
     scaler : str
         Scaling strategy ("per_series" or "revin").
     val_policy : str
@@ -93,6 +101,8 @@ class PatchTSTParams:
     patience: int = 20
     loss: str = "smape"
     loss_alpha: float = 0.5
+    kappa: float = 1.0
+    epsilon_leaky: float = 1e-8
     scaler: str = "per_series"
     num_workers: int = 0
     # validation settings (mirrors TrainConfig)

--- a/configs/patchtst.yaml
+++ b/configs/patchtst.yaml
@@ -6,3 +6,5 @@ rocv_val_span_days: 7
 purge_days: 28
 use_weighted_loss: true
 priority_weight: 3.0
+kappa: 1.0
+epsilon_leaky: 1.0e-8


### PR DESCRIPTION
## Summary
- add `kappa` and `epsilon_leaky` to `PatchTSTParams` with defaults and docs
- expose new parameters in default settings and YAML config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a746f5f7888328a17cf0a80c1e8988