### PR TITLE
refactor: extend PatchTST hyperparams

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -41,7 +41,8 @@ PATCH_PARAMS = dict(
     id_embed_dim=16,
     lr=1e-3, weight_decay=1e-4, batch_size=256,
     max_epochs=200, patience=20,
-    kappa=1.0, epsilon_leaky=1e-8,
+    lambda_nb=1.0, lambda_clf=1.0, lambda_s=0.05,
+    gamma=2.0, alpha=0.25, epsilon_leaky=0.0,
     num_workers=0,
 )
 TRAIN_CFG = dict(

--- a/LGHackerton/models/patchtst/trainer.py
+++ b/LGHackerton/models/patchtst/trainer.py
@@ -60,8 +60,16 @@ class PatchTSTParams:
         Loss function to use during optimisation.
     loss_alpha : float
         Mixing factor when ``loss`` is ``"hybrid"``.
-    kappa : float
-        Scaling factor applied within the loss function.
+    lambda_nb : float
+        Weight for the negative binomial regression loss component.
+    lambda_clf : float
+        Weight for the classifier loss component.
+    lambda_s : float
+        Scaling applied to the sparsity regularisation term.
+    gamma : float
+        Gamma parameter for focal loss.
+    alpha : float
+        Alpha parameter for focal loss.
     epsilon_leaky : float
         Small constant added for numerical stability in leaky operations.
     scaler : str
@@ -102,8 +110,12 @@ class PatchTSTParams:
     patience: int = 20
     loss: str = "smape"
     loss_alpha: float = 0.5
-    kappa: float = 1.0
-    epsilon_leaky: float = 1e-8
+    lambda_nb: float = 1.0
+    lambda_clf: float = 1.0
+    lambda_s: float = 0.05
+    gamma: float = 2.0
+    alpha: float = 0.25
+    epsilon_leaky: float = 0.0
     scaler: str = "per_series"
     num_workers: int = 0
     # validation settings (mirrors TrainConfig)

--- a/configs/patchtst.yaml
+++ b/configs/patchtst.yaml
@@ -6,5 +6,9 @@ rocv_val_span_days: 7
 purge_days: 28
 use_weighted_loss: true
 priority_weight: 3.0
-kappa: 1.0
-epsilon_leaky: 1.0e-8
+lambda_nb: 1.0
+lambda_clf: 1.0
+lambda_s: 0.05
+gamma: 2.0
+alpha: 0.25
+epsilon_leaky: 0.0

--- a/tests/test_pipeline_patchtst.py
+++ b/tests/test_pipeline_patchtst.py
@@ -43,7 +43,7 @@ def test_pipeline_patchtst(tmp_path):
         "PatchTSTTrainer.load=lambda self, path: None\n"
         "\n"
         "def _predict(self, X, sid_idx):\n"
-        "    k = self.params.kappa\n"
+        "    k = 1.0\n"
         "    eps = self.params.epsilon_leaky\n"
         "    import numpy as np\n"
         "    mu = np.full((len(X), self.H), 2.0, dtype=float)\n"
@@ -105,7 +105,7 @@ def test_pipeline_patchtst(tmp_path):
     assert pred_csv.exists()
     pred_df = pd.read_csv(pred_csv)
     kappa = 1.0
-    eps = 1e-8
+    eps = 0.0
     mu = 2.0
     prob = 0.5
     p0 = (kappa / (kappa + mu)) ** kappa


### PR DESCRIPTION
## Summary
- remove unused kappa from PatchTST params
- add new loss weighting and focal parameters with defaults
- propagate new params to default config and YAML

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7b4e437048328bba0e51fab1d9c70