### PR TITLE
Cast submission predictions to float

### DIFF
--- a/LGHackerton/postprocess/convert.py
+++ b/LGHackerton/postprocess/convert.py
@@ -143,10 +143,12 @@ def convert_to_submission(
     wide = wide.reindex(sample_df.iloc[:, 0]).reindex(
         columns=sample_df.columns[1:], fill_value=0.0
     )
+    wide = wide.astype(float)
 
     _missing_checks(pred_df)
 
     out_df = sample_df.copy()
+    out_df = out_df.astype({col: float for col in out_df.columns[1:]})
     out_df.iloc[:, 1:] = wide.to_numpy()
     assert list(out_df.columns) == list(sample_df.columns)
     return out_df


### PR DESCRIPTION
## Summary
- Prevent dtype warnings in submission conversion by casting prediction columns to float

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7d3787bd88328bd676a1a56156157