### PR TITLE
Allow tensor kappa in PatchTST SMAPE and expose loss helpers

### DIFF
--- a/LGHackerton/models/patchtst/__init__.py
+++ b/LGHackerton/models/patchtst/__init__.py
@@ -5,6 +5,20 @@ PatchTST model. It is intentionally lightweight so that other modules can
 import the losses without pulling in heavy training dependencies.
 """
 
-from .train import WeightedSMAPELoss, build_loss
+from .train import (
+    WeightedSMAPELoss,
+    build_loss,
+    trunc_nb_nll,
+    focal_loss,
+    combine_predictions,
+    weighted_smape_oof,
+)
 
-__all__ = ["WeightedSMAPELoss", "build_loss"]
+__all__ = [
+    "WeightedSMAPELoss",
+    "build_loss",
+    "trunc_nb_nll",
+    "focal_loss",
+    "combine_predictions",
+    "weighted_smape_oof",
+]

--- a/LGHackerton/models/patchtst/train.py
+++ b/LGHackerton/models/patchtst/train.py
@@ -250,7 +250,7 @@ def weighted_smape_oof(
     y_true: Tensor,
     clf_prob: Tensor,
     reg_pred: Tensor,
-    kappa: float,
+    kappa: Tensor,
     epsilon_leaky: float,
     w: Optional[Tensor] = None,
 ) -> Tensor:
@@ -265,7 +265,7 @@ def weighted_smape_oof(
     reg_pred:
         Regression predictions representing ``mu_u``.
     kappa:
-        Shape parameter for the zero probability computation.
+        Per-sample shape parameters controlling the zero probability.
     epsilon_leaky:
         Small constant added to the classifier probability.
     w:

--- a/tests/test_patchtst_loss_helpers.py
+++ b/tests/test_patchtst_loss_helpers.py
@@ -1,0 +1,30 @@
+import pathlib
+import sys
+
+import torch
+
+# Add project root to sys.path for module imports
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from LGHackerton.models.patchtst import (
+    combine_predictions,
+    focal_loss,
+    trunc_nb_nll,
+    weighted_smape_oof,
+)
+
+
+def test_weighted_smape_oof_accepts_tensor_kappa():
+    """weighted_smape_oof should handle per-sample kappa tensors."""
+    y_true = torch.tensor([0.0, 1.0])
+    clf_prob = torch.tensor([0.2, 0.8])
+    reg_pred = torch.tensor([0.3, 0.5])
+    kappa = torch.tensor([1.0, 2.0])
+    loss = weighted_smape_oof(y_true, clf_prob, reg_pred, kappa, 0.1)
+    assert loss.ndim == 0
+
+
+def test_patchtst_exports_loss_helpers():
+    """The patchtst package should expose utility functions for external use."""
+    for fn in (trunc_nb_nll, focal_loss, combine_predictions, weighted_smape_oof):
+        assert callable(fn)


### PR DESCRIPTION
## Summary
- Support per-sample `kappa` tensors in `weighted_smape_oof`
- Re-export PatchTST loss utilities for external use
- Add tests covering new loss helper exports and tensor `kappa`

## Testing
- `pytest tests/test_patchtst_loss_helpers.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7d72635f88328a4279ad7cb5884db