### PR TITLE
Clarify hurdle model training and stabilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ mean ``\mu_c`` is then ``\mu_u / (1 - P0)`` and the final prediction becomes::
 
     y_hat = ((1 - \epsilon_{leaky}) * p + \epsilon_{leaky}) * \mu_c
 
-The shape parameter ``kappa`` and the leakage term ``epsilon_leaky`` can be
-configured via ``PATCH_PARAMS`` and control the zero-probability assumption and
-stability of the combination respectively.
+During training the model jointly learns the mean ``\mu`` and shape ``\kappa``
+of a truncated negative binomial distribution, while the binary head employs
+focal loss. The leakage term ``epsilon_leaky``, configurable via ``PATCH_PARAMS``,
+stabilizes the blend by keeping a small positive probability even when the
+classifier predicts zero.
 
 ## Preprocessing
 


### PR DESCRIPTION
## Summary
- Describe joint learning of mean and dispersion in the hurdle model
- Mention truncated negative binomial with focal loss and explain `epsilon_leaky`'s role

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7e426ea148328901324ded72ac207