### PR TITLE
Remove unused loss parameters from PatchTSTParams

### DIFF
--- a/LGHackerton/models/patchtst/trainer.py
+++ b/LGHackerton/models/patchtst/trainer.py
@@ -56,10 +56,6 @@ class PatchTSTParams:
         Maximum number of training epochs per fold.
     patience : int
         Early stopping patience measured in epochs.
-    loss : str
-        Loss function to use during optimisation.
-    loss_alpha : float
-        Mixing factor when ``loss`` is ``"hybrid"``.
     lambda_nb : float
         Weight for the negative binomial regression loss component.
     lambda_clf : float
@@ -108,8 +104,6 @@ class PatchTSTParams:
     batch_size: int = 256
     max_epochs: int = 200
     patience: int = 20
-    loss: str = "smape"
-    loss_alpha: float = 0.5
     lambda_nb: float = 1.0
     lambda_clf: float = 1.0
     lambda_s: float = 0.05


### PR DESCRIPTION
## Summary
- clean up PatchTSTParams by removing the unused `loss` and `loss_alpha` settings
- update trainer documentation and defaults accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7e43d37d0832884494929809b0f94