### PR TITLE
Rename reg_pred parameter to mu in PatchTST helpers

### DIFF
--- a/LGHackerton/models/patchtst/train.py
+++ b/LGHackerton/models/patchtst/train.py
@@ -249,7 +249,7 @@ def combine_predictions(
 def weighted_smape_oof(
     y_true: Tensor,
     clf_prob: Tensor,
-    reg_pred: Tensor,
+    mu: Tensor,
     kappa: Tensor,
     epsilon_leaky: float,
     w: Optional[Tensor] = None,
@@ -262,7 +262,7 @@ def weighted_smape_oof(
         Ground truth demand.
     clf_prob:
         Probability estimates from the classifier.
-    reg_pred:
+    mu:
         Regression predictions representing ``mu_u``.
     kappa:
         Per-sample shape parameters controlling the zero probability.
@@ -271,7 +271,7 @@ def weighted_smape_oof(
     w:
         Optional sample weights.
     """
-    final_pred = combine_predictions(clf_prob, reg_pred, kappa, epsilon_leaky)
+    final_pred = combine_predictions(clf_prob, mu, kappa, epsilon_leaky)
     loss_fn = WeightedSMAPELoss(reduction="mean")
     return loss_fn(final_pred, y_true, w=w)
 

--- a/tests/test_patchtst_loss_helpers.py
+++ b/tests/test_patchtst_loss_helpers.py
@@ -18,9 +18,9 @@ def test_weighted_smape_oof_accepts_tensor_kappa():
     """weighted_smape_oof should handle per-sample kappa tensors."""
     y_true = torch.tensor([0.0, 1.0])
     clf_prob = torch.tensor([0.2, 0.8])
-    reg_pred = torch.tensor([0.3, 0.5])
+    mu = torch.tensor([0.3, 0.5])
     kappa = torch.tensor([1.0, 2.0])
-    loss = weighted_smape_oof(y_true, clf_prob, reg_pred, kappa, 0.1)
+    loss = weighted_smape_oof(y_true, clf_prob, mu, kappa, 0.1)
     assert loss.ndim == 0
 
 


### PR DESCRIPTION
## Summary
- rename `reg_pred` argument to `mu` in `weighted_smape_oof`
- adjust tests for new parameter name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7e5554d548328a8c763228b8bfabd