### PR TITLE
Enable cyclical calendar features by default

### DIFF
--- a/tests/test_calendar_feature_maker.py
+++ b/tests/test_calendar_feature_maker.py
@@ -21,23 +21,23 @@ def _sample_df() -> pd.DataFrame:
 
 def test_cyclical_reduces_columns_and_variance():
     df = _sample_df()
-    base = CalendarFeatureMaker().fit(df).transform(df)
-    cyc = CalendarFeatureMaker(cyclical=True).fit(df).transform(df)
+    cyc = CalendarFeatureMaker().fit(df).transform(df)
+    dum = CalendarFeatureMaker(cyclical=False).fit(df).transform(df)
 
-    base_cols = [c for c in base.columns if c.startswith("month_") or c.startswith("woy_")]
     cyc_cols = [c for c in cyc.columns if c.endswith("_sin") or c.endswith("_cos")]
+    dum_cols = [c for c in dum.columns if c.startswith("month_") or c.startswith("woy_")]
 
-    assert len(cyc_cols) < len(base_cols)
+    assert len(cyc_cols) < len(dum_cols)
 
-    base_var = base[base_cols].var().sum()
     cyc_var = cyc[cyc_cols].var().sum()
-    assert cyc_var < base_var
+    dum_var = dum[dum_cols].var().sum()
+    assert cyc_var < dum_var
 
 
 def test_keep_selected_reduces_columns_and_variance():
     df = _sample_df()
-    base = CalendarFeatureMaker().fit(df).transform(df)
-    kept = CalendarFeatureMaker(keep_months=[1], keep_woys=[1, 2]).fit(df).transform(df)
+    base = CalendarFeatureMaker(cyclical=False).fit(df).transform(df)
+    kept = CalendarFeatureMaker(cyclical=False, keep_months=[1], keep_woys=[1, 2]).fit(df).transform(df)
 
     base_cols = [c for c in base.columns if c.startswith("month_") or c.startswith("woy_")]
     kept_cols = [c for c in kept.columns if c.startswith("month_") or c.startswith("woy_")]


### PR DESCRIPTION
## Summary
- Default calendar feature maker to cyclical encoding with sine/cosine outputs and add conditional dummy generation for non-cyclical mode
- Explicitly initialize Preprocessor with cyclical calendar features
- Update calendar feature maker tests to verify new cyclical default and keep-month/week filters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a802c4e40c83289a02c240025fbdaf