### PR TITLE
Remove day column from calendar features

### DIFF
--- a/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
+++ b/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
@@ -290,7 +290,7 @@ class CalendarFeatureMaker:
             if c in df.columns
         ]
         self._promo_col = promo_candidates[0] if promo_candidates else None
-        base = ["year", "day"]
+        base = ["year"]
         if self.dow_mode == "cyclical":
             base.extend(["dow_sin", "dow_cos"])
         else:
@@ -316,7 +316,6 @@ class CalendarFeatureMaker:
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
         d = df.copy()
         d["year"] = d[DATE_COL].dt.year
-        d["day"] = d[DATE_COL].dt.day
         d["dow"] = d[DATE_COL].dt.weekday  # 0=Mon
         d["is_weekend"] = d["dow"].isin([5, 6]).astype(np.int8)
         d["is_month_start"] = d[DATE_COL].dt.is_month_start.astype(np.int8)

--- a/tests/test_calendar_feature_maker.py
+++ b/tests/test_calendar_feature_maker.py
@@ -58,6 +58,7 @@ def test_keep_selected_reduces_columns_and_variance():
 def test_dow_modes(mode):
     df = _sample_df()
     out = CalendarFeatureMaker(dow_mode=mode).fit(df).transform(df)
+    assert "day" not in out.columns
     if mode == "cyclical":
         assert "dow" not in out.columns
         assert {"dow_sin", "dow_cos"}.issubset(out.columns)


### PR DESCRIPTION
## Summary
- drop `day` column from `CalendarFeatureMaker` output and feature list
- add regression test ensuring `day` column is absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a80609e11083288cbf23dfdea25428