### PR TITLE
feat: support static features in patch windowizer

### DIFF
--- a/tests/test_patch_windowizer.py
+++ b/tests/test_patch_windowizer.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from LGHackerton.preprocess.preprocess_pipeline_v1_1 import (
+    SampleWindowizer,
+    SERIES_COL,
+    DATE_COL,
+    SALES_COL,
+    SALES_FILLED_COL,
+)
+
+
+def test_patch_windowizer_dynamic_static():
+    dates = pd.date_range("2020-01-01", periods=5, freq="D")
+    records = []
+    for i, d in enumerate(dates):
+        records.append(
+            {
+                SERIES_COL: "A",
+                DATE_COL: d,
+                SALES_COL: float(i + 1),
+                SALES_FILLED_COL: float(i + 1),
+                "feat_dyn": float(i),
+                "feat_static": 42.0,
+            }
+        )
+    df = pd.DataFrame(records)
+
+    feature_cols = ["feat_dyn", "feat_static"]
+    static_cols = ["feat_static"]
+
+    win = SampleWindowizer(lookback=3, horizon=2)
+    X, Y, sids, dates = win.build_patch_train(df, feature_cols, static_cols)
+
+    assert X.shape == (1, 3, 3)
+    expected_dyn = df.loc[0:2, [SALES_FILLED_COL, "feat_dyn"]].values
+    expected_stat = np.repeat([[42.0]], 3, axis=0)
+    expected = np.concatenate([expected_dyn, expected_stat], axis=1)
+    np.testing.assert_allclose(X[0], expected)
+    np.testing.assert_allclose(Y[0], df.loc[3:4, SALES_COL].values)
+    assert win.dynamic_idx[SALES_FILLED_COL] == 0
+    assert win.dynamic_idx["feat_dyn"] == 1
+    assert win.static_idx["feat_static"] == 2
+
+    X_eval, sids_eval, dates_eval = win.build_patch_eval(df, feature_cols, static_cols)
+    assert X_eval.shape == (1, 3, 3)
+    expected_eval_dyn = df.loc[2:4, [SALES_FILLED_COL, "feat_dyn"]].values
+    expected_eval = np.concatenate([expected_eval_dyn, expected_stat], axis=1)
+    np.testing.assert_allclose(X_eval[0], expected_eval)
+    assert sids_eval[0] == "A"
+    assert dates_eval.shape == (1,)


### PR DESCRIPTION
## Summary
- allow SampleWindowizer.patch_* to accept feature and static columns
- propagate static feature handling through Preprocessor
- add tests for dynamic/static channel order in Patch windows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a80975e3b48328b87709fceba1547c