### PR TITLE
Pass feature index maps through PatchTST data loaders

### DIFF
--- a/tests/test_pipeline_patchtst.py
+++ b/tests/test_pipeline_patchtst.py
@@ -42,7 +42,7 @@ def test_pipeline_patchtst(tmp_path):
         "\n"
         "PatchTSTTrainer.load=lambda self, path: None\n"
         "\n"
-        "def _predict(self, X, sid_idx):\n"
+        "def _predict(self, X, sid_idx, dyn_idx=None, static_idx=None):\n"
         "    k = 1.0\n"
         "    eps = self.params.epsilon_leaky\n"
         "    import numpy as np\n"


### PR DESCRIPTION
## Summary
- Ensure `Preprocessor` exposes `patch_dynamic_idx` and `patch_static_idx` when building datasets
- Pass fold-specific dynamic/static indices into PatchTST training and prediction datasets
- Extend trainer prediction API and pipeline test stub to accept channel index maps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a817f363088328a3fcb77a9a5af281