### PR TITLE
Remove unused PatchTST intermittency features

### DIFF
--- a/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
+++ b/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
@@ -836,6 +836,8 @@ class Preprocessor:
             "woy_sin",
             "woy_cos",
             "is_promo",
+            "zero_ratio_28",
+            "days_since_last_sale",
         }
         self.patch_feature_cols = [
             c

--- a/tests/test_patchtst_feature_filter.py
+++ b/tests/test_patchtst_feature_filter.py
@@ -64,3 +64,26 @@ def test_patchtst_dynamic_channels_drop_lag_roll():
         not k.startswith("lag_") and not k.startswith("roll_")
         for k in pp.patch_dynamic_idx
     )
+
+
+def test_patchtst_intermittency_features():
+    pp = Preprocessor()
+    pp.guard.set_scope("train")
+
+    # Feature columns including intermittency indicators
+    pp.feature_cols = [
+        "zero_ratio_28",
+        "days_since_last_sale",
+        "zero_run_len",
+        "dow",
+    ]
+    pp.static_feature_cols = []
+    pp.dynamic_feature_cols = [c for c in pp.feature_cols]
+
+    # Compute PatchTST feature lists
+    pp._compute_patch_features()
+
+    # Only zero_run_len should remain among intermittency features
+    assert "zero_run_len" in pp.patch_feature_cols
+    assert "zero_ratio_28" not in pp.patch_feature_cols
+    assert "days_since_last_sale" not in pp.patch_feature_cols


### PR DESCRIPTION
## Summary
- Exclude `zero_ratio_28` and `days_since_last_sale` from PatchTST features, keeping only `zero_run_len`
- Test that only `zero_run_len` remains among intermittency indicators

## Testing
- `pytest tests/test_patchtst_feature_filter.py`


------
https://chatgpt.com/codex/tasks/task_e_68a85822b7f08328a57be78b2702dc80