### PR TITLE
Exclude series_code from PatchTST features

### DIFF
--- a/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
+++ b/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
@@ -848,6 +848,7 @@ class Preprocessor:
             "is_promo",
             "zero_ratio_28",
             "days_since_last_sale",
+            "series_code",
         }
         self.patch_feature_cols = [
             c

--- a/tests/test_patchtst_feature_filter.py
+++ b/tests/test_patchtst_feature_filter.py
@@ -87,3 +87,18 @@ def test_patchtst_intermittency_features():
     assert "zero_run_len" in pp.patch_feature_cols
     assert "zero_ratio_28" not in pp.patch_feature_cols
     assert "days_since_last_sale" not in pp.patch_feature_cols
+
+
+def test_patchtst_drop_series_code():
+    pp = Preprocessor()
+    pp.guard.set_scope("train")
+
+    pp.feature_cols = ["series_code", "shop_code", "menu_code"]
+    pp.static_feature_cols = ["shop_code", "menu_code"]
+    pp.dynamic_feature_cols = [c for c in pp.feature_cols if c not in pp.static_feature_cols]
+
+    pp._compute_patch_features()
+
+    assert "series_code" not in pp.patch_feature_cols
+    assert "shop_code" in pp.patch_feature_cols
+    assert "menu_code" in pp.patch_feature_cols


### PR DESCRIPTION
## Summary
- Prevent PatchTST from using `series_code` by adding it to the feature exclusion list.
- Add regression test confirming `series_code` is omitted while `shop_code` and `menu_code` remain available.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a85ad08fa883289c7564c540b9284f