### PR TITLE
Improve PatchTST tuning error logging

### DIFF
--- a/LGHackerton/tuning/patchtst.py
+++ b/LGHackerton/tuning/patchtst.py
@@ -341,7 +341,9 @@ class PatchTSTTuner(HyperparameterTuner):
                 return float(score)
             except Exception as e:  # pragma: no cover - robustness
                 trial.set_user_attr("status", "failed")
-                raise optuna.TrialPruned() from e
+                trial.set_user_attr("fail_reason", repr(e))
+                logging.exception("PatchTST trial %s failed", trial.number)
+                raise optuna.TrialPruned(str(e)) from e
             finally:
                 if callback_registered:
                     try:


### PR DESCRIPTION
## Summary
- Log full exception info during PatchTST tuning trials
- Attach failure reason to Optuna trial before pruning

## Testing
- `python - <<'PY' ...` (demo of exception logging)
- `PYTHONPATH=. pytest tests/test_patchtst_logging_adapter.py tests/test_tuner_validation.py::test_patchtst_validate_params -q`


------
https://chatgpt.com/codex/tasks/task_e_68a85fd575fc8328ac5777c0c030af2b