### PR TITLE
Expand PatchTST tuning ranges

### DIFF
--- a/LGHackerton/tuning/patchtst.py
+++ b/LGHackerton/tuning/patchtst.py
@@ -35,14 +35,13 @@ except Exception:  # pragma: no cover - torch optional
 class PatchTSTSearchSpace:
     """Search space definitions for PatchTST hyperparameters.
 
-    This configuration uses a reduced search range focusing on smaller
-    embedding sizes and shallower Transformer depth:
+    This search space mirrors the recommended tuning ranges:
 
-    ``d_model``=(128, 192, 256), ``n_heads``=(4, 8), ``depth``=(1, 2),
-    ``patch_len``/``stride``=(8, 12, 14, 16), ``dropout`` in [0.40, 0.60],
-    ``lr`` in [1e-3, 5e-3], ``weight_decay`` in [1e-4, 5e-4],
-    ``id_embed_dim``=(8, 16, 32), ``batch_size``=(32, 64),
-    ``max_epochs`` in [60, 80], ``patience`` in [10, 15].
+    ``d_model``={128, 256, 384, 512}, ``n_heads``={8, 16}, ``depth`` in [2, 6],
+    ``patch_len``/``stride``={8, 16, 24, 32}, ``dropout`` in [0.10, 0.30],
+    ``lr`` in [1e-4, 3e-3], ``weight_decay`` in [1e-5, 1e-3],
+    ``id_embed_dim``={16, 32, 64}, ``batch_size``={64, 128},
+    ``max_epochs`` in [80, 150], ``patience`` in [15, 30].
 
     Attributes
     ----------
@@ -72,18 +71,18 @@ class PatchTSTSearchSpace:
         Inclusive range for early-stopping patience.
     """
 
-    d_model: Tuple[int, ...] = (128, 192, 256)
-    n_heads: Tuple[int, ...] = (4, 8)
-    depth: Tuple[int, int] = (1, 2)
-    patch_len: Tuple[int, ...] = (8, 12, 14, 16)
-    stride: Tuple[int, ...] = (8, 12, 14, 16)
-    dropout: Tuple[float, float] = (0.40, 0.60)
-    lr: Tuple[float, float] = (1e-3, 5e-3)
-    weight_decay: Tuple[float, float] = (1e-4, 5e-4)
-    id_embed_dim: Tuple[int, ...] = (8, 16, 32)
-    batch_size: Tuple[int, ...] = (32, 64)
-    max_epochs: Tuple[int, int] = (60, 80)
-    patience: Tuple[int, int] = (10, 15)
+    d_model: Tuple[int, ...] = (128, 256, 384, 512)
+    n_heads: Tuple[int, ...] = (8, 16)
+    depth: Tuple[int, int] = (2, 6)
+    patch_len: Tuple[int, ...] = (8, 16, 24, 32)
+    stride: Tuple[int, ...] = (8, 16, 24, 32)
+    dropout: Tuple[float, float] = (0.10, 0.30)
+    lr: Tuple[float, float] = (1e-4, 3e-3)
+    weight_decay: Tuple[float, float] = (1e-5, 1e-3)
+    id_embed_dim: Tuple[int, ...] = (16, 32, 64)
+    batch_size: Tuple[int, ...] = (64, 128)
+    max_epochs: Tuple[int, int] = (80, 150)
+    patience: Tuple[int, int] = (15, 30)
 
 
 def _log_fold_start(

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -47,17 +47,17 @@ The following tables list the default ranges or choices used during tuning.
 
 | Parameter | Range/Choices |
 |-----------|---------------|
-| `d_model` | 64, 128, 256 |
-| `n_heads` | 4, 8 |
+| `d_model` | 128, 256, 384, 512 |
+| `n_heads` | 8, 16 |
 | `depth` | 2–6 |
-| `patch_len`/`stride` | 8, 12, 14, 16, 24 |
-| `dropout` | 0.0–0.5 |
-| `lr` | 1e-4–1e-2 (log) |
-| `weight_decay` | 1e-6–1e-3 (log) |
-| `id_embed_dim` | 0, 16 |
-| `batch_size` | 64, 128, 256 |
-| `max_epochs` | 50–200 |
-| `patience` | 5–30 |
+| `patch_len`/`stride` | 8, 16, 24, 32 |
+| `dropout` | 0.10–0.30 |
+| `lr` | 1e-4–3e-3 (log) |
+| `weight_decay` | 1e-5–1e-3 (log) |
+| `id_embed_dim` | 16, 32, 64 |
+| `batch_size` | 64, 128 |
+| `max_epochs` | 80–150 |
+| `patience` | 15–30 |
 
 ### LightGBM
 


### PR DESCRIPTION
## Summary
- broaden PatchTST hyperparameter search to larger model sizes and training windows
- document new PatchTST tuning ranges

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a86567a9148328911ee434e325c76d