### PR TITLE
Add Optuna trial and timeout options to training config

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -59,4 +59,6 @@ TRAIN_CFG = dict(
     purge_days=28,
     min_val_samples=28,
     purge_mode="L",
+    n_trials=20,
+    timeout=None,
 )

--- a/LGHackerton/models/base_trainer.py
+++ b/LGHackerton/models/base_trainer.py
@@ -26,6 +26,8 @@ class TrainConfig:
     min_val_samples:int=28           # minimum validation samples per fold
     purge_mode:str="L"               # fallback for legacy behaviour
     input_lens: List[int] | None = None
+    n_trials:int=20
+    timeout:int|None=None
 
 class BaseModel(ABC):
     def __init__(self, model_params: Dict[str, Any], model_dir: str):


### PR DESCRIPTION
## Summary
- add `n_trials` and `timeout` options to `TrainConfig`
- expose new defaults in `TRAIN_CFG`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a86c8372ac83288bd5902afbe81262