### PR TITLE
feat: report training metrics to optuna

### DIFF
--- a/LGHackerton/tuning/patchtst.py
+++ b/LGHackerton/tuning/patchtst.py
@@ -350,7 +350,15 @@ class PatchTSTTuner(HyperparameterTuner):
                     device=device,
                 )
 
-                trainer.train(X, y, series_ids, label_dates, self.cfg, [self.pp])
+                trainer.train(
+                    X,
+                    y,
+                    series_ids,
+                    label_dates,
+                    self.cfg,
+                    [self.pp],
+                    trial=trial,
+                )
                 oof = trainer.get_oof()
                 outlets = oof["series_id"].str.split("::").str[0].values
                 score = weighted_smape_np(


### PR DESCRIPTION
## Summary
- add Optuna dependency to PatchTST trainer
- report validation wSMAPE each epoch and prune when needed
- pass Optuna trial through tuning objective

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a86e19769083289449788f62ad016a