### PR TITLE
Validate dynamic channel presence in SeriesDataset

### DIFF
--- a/LGHackerton/models/patchtst/trainer.py
+++ b/LGHackerton/models/patchtst/trainer.py
@@ -150,6 +150,8 @@ class _SeriesDataset(Dataset):
             static_idx = static_idx.values()
         self.dyn_idx = sorted(dyn_idx) if dyn_idx is not None else [0]
         self.static_idx = sorted(static_idx) if static_idx is not None else []
+        if not self.dyn_idx:
+            raise ValueError("at least one dynamic channel required")
 
         # Pre-compute mean and std for each dynamic channel
         dyn = self.X[:, :, self.dyn_idx]

--- a/tests/test_patchtst_series_dataset.py
+++ b/tests/test_patchtst_series_dataset.py
@@ -1,0 +1,11 @@
+import numpy as np
+import pytest
+
+from LGHackerton.models.patchtst.trainer import _SeriesDataset
+
+
+def test_series_dataset_requires_dynamic_channel():
+    X = np.zeros((2, 5, 1), dtype=np.float32)
+    y = np.zeros((2,), dtype=np.float32)
+    with pytest.raises(ValueError, match="at least one dynamic channel required"):
+        _SeriesDataset(X, y, dyn_idx=[], static_idx=[0])


### PR DESCRIPTION
## Summary
- raise ValueError when `_SeriesDataset` receives no dynamic channel indices
- add regression test verifying the error is thrown for empty dynamic channel list

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a86fe72000832888d3819e9d56c3db