### PR TITLE
Require explicit dynamic indices for PatchTST series dataset

### DIFF
--- a/LGHackerton/models/patchtst/trainer.py
+++ b/LGHackerton/models/patchtst/trainer.py
@@ -148,10 +148,10 @@ class _SeriesDataset(Dataset):
             dyn_idx = dyn_idx.values()
         if isinstance(static_idx, dict):
             static_idx = static_idx.values()
-        self.dyn_idx = sorted(dyn_idx) if dyn_idx is not None else [0]
+        if dyn_idx is None or len(dyn_idx) == 0:
+            raise ValueError("dynamic channel indices required")
+        self.dyn_idx = sorted(dyn_idx)
         self.static_idx = sorted(static_idx) if static_idx is not None else []
-        if not self.dyn_idx:
-            raise ValueError("at least one dynamic channel required")
 
         # Pre-compute mean and std for each dynamic channel
         dyn = self.X[:, :, self.dyn_idx]

--- a/tests/test_patchtst_series_dataset.py
+++ b/tests/test_patchtst_series_dataset.py
@@ -4,8 +4,9 @@ import pytest
 from LGHackerton.models.patchtst.trainer import _SeriesDataset
 
 
-def test_series_dataset_requires_dynamic_channel():
+@pytest.mark.parametrize("dyn_idx", [None, []])
+def test_series_dataset_requires_dynamic_channel(dyn_idx):
     X = np.zeros((2, 5, 1), dtype=np.float32)
     y = np.zeros((2,), dtype=np.float32)
-    with pytest.raises(ValueError, match="at least one dynamic channel required"):
-        _SeriesDataset(X, y, dyn_idx=[], static_idx=[0])
+    with pytest.raises(ValueError, match="dynamic channel indices required"):
+        _SeriesDataset(X, y, dyn_idx=dyn_idx, static_idx=[0])


### PR DESCRIPTION
## Summary
- enforce dynamic channel index specification in PatchTST `_SeriesDataset`
- test that missing or empty dynamic index raises `ValueError`

## Testing
- `PYTHONPATH=. pytest tests/test_patchtst_series_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_68a874a6fed0832888826e77499ff412