### PR TITLE
Exclude series_cv from PatchTST patch features

### DIFF
--- a/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
+++ b/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
@@ -875,6 +875,7 @@ class Preprocessor:
             "zero_ratio_28",
             "days_since_last_sale",
             "series_code",
+            "series_cv",
         }
         self.patch_feature_cols = [
             c

--- a/tests/test_patchtst_feature_filter.py
+++ b/tests/test_patchtst_feature_filter.py
@@ -102,3 +102,17 @@ def test_patchtst_drop_series_code():
     assert "series_code" not in pp.patch_feature_cols
     assert "shop_code" in pp.patch_feature_cols
     assert "menu_code" in pp.patch_feature_cols
+
+
+def test_patchtst_drop_series_cv():
+    pp = Preprocessor()
+    pp.guard.set_scope("train")
+
+    pp.feature_cols = ["series_cv", "dow"]
+    pp.static_feature_cols = []
+    pp.dynamic_feature_cols = [c for c in pp.feature_cols]
+
+    pp._compute_patch_features()
+
+    assert "series_cv" not in pp.patch_feature_cols
+    assert "dow" in pp.patch_feature_cols


### PR DESCRIPTION
## Summary
- Drop `series_cv` from PatchTST patch features
- Add regression test to ensure `series_cv` is excluded from patch feature columns

## Testing
- `pytest tests/test_patchtst_feature_filter.py::test_patchtst_drop_series_cv -q`
- `python - <<'PY'
from LGHackerton.preprocess import Preprocessor
from LGHackerton.config.default import TRAIN_PATH
from LGHackerton.utils.io import read_table
pp=Preprocessor(show_progress=False)
df_raw=read_table(TRAIN_PATH)
pp.fit_transform_train(df_raw)
print('series_cv' in pp.patch_feature_cols)
print(', '.join(pp.patch_feature_cols))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a889f745248328aa0812e7548e8598