### PR TITLE
Log PatchTST input dimensions during training

### DIFF
--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -4,6 +4,7 @@ import argparse
 import importlib
 import json
 import logging
+import sys
 import warnings
 from pathlib import Path
 import pandas as pd
@@ -166,6 +167,9 @@ def run_training(ctx: PipelineContext) -> None:
     except NotImplementedError as e:
         raise RuntimeError(f"{ctx.model_name} build_dataset not implemented") from e
     if ctx.model_name == "patchtst":
+        input_dim = X_train.shape[2] if X_train.ndim == 3 else 1
+        kind = "multivariate" if input_dim > 1 else "univariate"
+        logging.info("PatchTST training with %s input (%d features)", kind, input_dim)
         module = importlib.import_module(trainer_cls.__module__)
         if not getattr(module, "TORCH_OK", True):
             raise RuntimeError("PyTorch is not available")
@@ -213,6 +217,12 @@ def run_oof_prediction(ctx: PipelineContext) -> None:
 
 
 def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s:%(name)s:%(message)s",
+        stream=sys.stdout,
+        force=True,
+    )
     parser = argparse.ArgumentParser()
     parser.add_argument("--progress", dest="show_progress", action="store_true", help="show preprocessing progress")
     parser.add_argument("--no-progress", dest="show_progress", action="store_false", help="hide preprocessing progress")


### PR DESCRIPTION
## Summary
- log PatchTST input type and feature count when building the dataset
- configure logging to always emit INFO messages to the console

## Testing
- `pytest tests/test_patchtst_logging_adapter.py tests/test_patchtst_feature_filter.py`


------
https://chatgpt.com/codex/tasks/task_e_68a89983c6ec832890cc419d449e22d7