### PR TITLE
Apply RevIN normalization only to target channel

### DIFF
--- a/LGHackerton/models/patchtst/trainer.py
+++ b/LGHackerton/models/patchtst/trainer.py
@@ -171,8 +171,9 @@ class _SeriesDataset(Dataset):
         x = self.X[idx].copy()
         mu = np.float32(self.mu[idx])
         std = np.float32(self.std[idx])
-        # normalise dynamic channels only
-        x[:, self.dyn_idx] = (x[:, self.dyn_idx] - mu) / std
+        # normalise only the target dynamic channel
+        tgt_ch = self.dyn_idx[0]
+        x[:, tgt_ch] = (x[:, tgt_ch] - mu[0]) / std[0]
         y = self.y[idx]
         if self.scaler == "revin":
             y = (y - self.mu_base[idx]) / self.std_base[idx]

--- a/tests/test_patchtst_series_dataset.py
+++ b/tests/test_patchtst_series_dataset.py
@@ -10,3 +10,19 @@ def test_series_dataset_requires_dynamic_channel(dyn_idx):
     y = np.zeros((2,), dtype=np.float32)
     with pytest.raises(ValueError, match="dynamic channel indices required"):
         _SeriesDataset(X, y, dyn_idx=dyn_idx, static_idx=[0])
+
+
+def test_revin_normalizes_only_target_channel():
+    """Ensure RevIN scaling applies only to the target channel."""
+    X = np.array([
+        [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]],
+    ], dtype=np.float32)
+    y = np.zeros((1,), dtype=np.float32)
+    ds = _SeriesDataset(X, y, dyn_idx=[0, 1], scaler="revin")
+    x, *_ = ds[0]
+
+    tgt = X[0, :, 0]
+    expected = (tgt - tgt.mean()) / tgt.std()
+    assert np.allclose(x[:, 0], expected)
+    # second dynamic channel should remain unchanged
+    assert np.allclose(x[:, 1], X[0, :, 1])


### PR DESCRIPTION
## Summary
- Normalize only the target dynamic channel in `_SeriesDataset.__getitem__`
- Add test ensuring RevIN scaling leaves non-target channels unchanged

## Testing
- `PYTHONPATH=$PWD pytest tests/test_patchtst_series_dataset.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a903ee30308328b8d2c60a1b3a6ed4