### PR TITLE
Normalize all dynamic channels in PatchTST dataset

### DIFF
--- a/LGHackerton/models/patchtst/trainer.py
+++ b/LGHackerton/models/patchtst/trainer.py
@@ -171,9 +171,8 @@ class _SeriesDataset(Dataset):
         x = self.X[idx].copy()
         mu = np.float32(self.mu[idx])
         std = np.float32(self.std[idx])
-        # normalise only the target dynamic channel
-        tgt_ch = self.dyn_idx[0]
-        x[:, tgt_ch] = (x[:, tgt_ch] - mu[0]) / std[0]
+        # normalise all dynamic channels using their own statistics
+        x[:, self.dyn_idx] = (x[:, self.dyn_idx] - mu) / std
         y = self.y[idx]
         if self.scaler == "revin":
             y = (y - self.mu_base[idx]) / self.std_base[idx]

--- a/tests/test_patchtst_series_dataset.py
+++ b/tests/test_patchtst_series_dataset.py
@@ -12,8 +12,8 @@ def test_series_dataset_requires_dynamic_channel(dyn_idx):
         _SeriesDataset(X, y, dyn_idx=dyn_idx, static_idx=[0])
 
 
-def test_revin_normalizes_only_target_channel():
-    """Ensure RevIN scaling applies only to the target channel."""
+def test_revin_normalizes_all_dynamic_channels():
+    """Ensure RevIN scaling applies to all dynamic channels."""
     X = np.array([
         [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]],
     ], dtype=np.float32)
@@ -22,7 +22,8 @@ def test_revin_normalizes_only_target_channel():
     x, *_ = ds[0]
 
     tgt = X[0, :, 0]
-    expected = (tgt - tgt.mean()) / tgt.std()
-    assert np.allclose(x[:, 0], expected)
-    # second dynamic channel should remain unchanged
-    assert np.allclose(x[:, 1], X[0, :, 1])
+    expected0 = (tgt - tgt.mean()) / tgt.std()
+    assert np.allclose(x[:, 0], expected0)
+    dyn2 = X[0, :, 1]
+    expected1 = (dyn2 - dyn2.mean()) / dyn2.std()
+    assert np.allclose(x[:, 1], expected1)


### PR DESCRIPTION
## Summary
- Normalize every dynamic feature in `_SeriesDataset.__getitem__` instead of just the target channel
- Update tests to verify per-channel normalization of dynamic features

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a90b8fc1508328bef2dbea78083d6c