### PR TITLE
feat: support static features in PatchTST dataset

### DIFF
--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -160,7 +160,7 @@ def run_training(ctx: PipelineContext) -> None:
     except AttributeError as e:
         raise RuntimeError(f"{ctx.model_name} build_dataset not implemented") from e
     try:
-        X_train, y_train, series_ids, label_dates = build_dataset(
+        X_train, S_train, y_train, series_ids, label_dates = build_dataset(
             ctx.preprocessor, ctx.df_full, ctx.input_len
         )
     except NotImplementedError as e:
@@ -181,7 +181,15 @@ def run_training(ctx: PipelineContext) -> None:
         if ctx.input_len is not None:
             trainer.L = ctx.input_len
         trainer.H = ctx.preprocessor.windowizer.H
-    trainer.train(X_train, y_train, series_ids, label_dates, ctx.cfg, [ctx.preprocessor])
+    trainer.train(
+        X_train,
+        S_train,
+        y_train,
+        series_ids,
+        label_dates,
+        ctx.cfg,
+        [ctx.preprocessor],
+    )
     ctx.oof_df = trainer.get_oof()
     model_path = ARTIFACTS_DIR / "models" / f"{ctx.model_name}.pt"
     if not model_path.exists():

--- a/LGHackerton/tune.py
+++ b/LGHackerton/tune.py
@@ -101,7 +101,7 @@ def run_patchtst_grid_search(cfg_path: str | Path) -> None:
 
     device = "cuda" if torch and torch.cuda.is_available() else "cpu"
     results: List[dict[str, Any]] = []
-    dataset_cache: dict[int, tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = {}
+    dataset_cache: dict[int, tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = {}
 
     # Prebuild datasets for each unique input length
     for inp in input_lens:
@@ -111,7 +111,7 @@ def run_patchtst_grid_search(cfg_path: str | Path) -> None:
 
     # Iterate over grid while reusing cached datasets
     for inp in input_lens:
-        X, y, series_ids, label_dates = dataset_cache[inp]
+        X, S, y, series_ids, label_dates = dataset_cache[inp]
         for patch, lr, scaler in itertools.product(patch_lens, lrs, scalers):
             if inp % patch != 0:
                 continue
@@ -127,7 +127,7 @@ def run_patchtst_grid_search(cfg_path: str | Path) -> None:
                 trainer = PatchTSTTrainer(
                     params=params, L=inp, H=H, model_dir=cfg.model_dir, device=device
                 )
-                trainer.train(X, y, series_ids, label_dates, cfg)
+                trainer.train(X, S, y, series_ids, label_dates, cfg)
                 oof = trainer.get_oof()
                 outlets = oof["series_id"].str.split("::").str[0].values
                 val_w = weighted_smape_np(

--- a/LGHackerton/tuning/patchtst.py
+++ b/LGHackerton/tuning/patchtst.py
@@ -293,18 +293,19 @@ class PatchTSTTuner(HyperparameterTuner):
                 input_len = trial.suggest_categorical("input_len", input_lens)
                 if input_len not in self._dataset_cache:
                     self.pp.windowizer = SampleWindowizer(lookback=input_len, horizon=H)
-                    X, y, series_ids, label_dates = self.pp.build_patch_train(self.df)
+                    X, S, y, series_ids, label_dates = self.pp.build_patch_train(self.df)
                     dyn_idx = getattr(self.pp, "patch_dynamic_idx", {}).copy()
                     stat_idx = getattr(self.pp, "patch_static_idx", {}).copy()
                     self._dataset_cache[input_len] = (
                         X,
+                        S,
                         y,
                         series_ids,
                         label_dates,
                         dyn_idx,
                         stat_idx,
                     )
-                X, y, series_ids, label_dates, dyn_idx, stat_idx = self._dataset_cache[input_len]
+                X, S, y, series_ids, label_dates, dyn_idx, stat_idx = self._dataset_cache[input_len]
                 # Reassign channel index maps to ensure they reflect the cached
                 # dataset's indices even if downstream steps mutate them.
                 self.pp.patch_dynamic_idx = dyn_idx.copy()
@@ -354,6 +355,7 @@ class PatchTSTTuner(HyperparameterTuner):
 
                 trainer.train(
                     X,
+                    S,
                     y,
                     series_ids,
                     label_dates,

--- a/tests/test_patchtst_series_dataset.py
+++ b/tests/test_patchtst_series_dataset.py
@@ -9,7 +9,7 @@ def test_series_dataset_requires_dynamic_channel(dyn_idx):
     X = np.zeros((2, 5, 1), dtype=np.float32)
     y = np.zeros((2,), dtype=np.float32)
     with pytest.raises(ValueError, match="dynamic channel indices required"):
-        _SeriesDataset(X, y, dyn_idx=dyn_idx, static_idx=[0])
+        _SeriesDataset(X, y, np.zeros((2, 0), dtype=np.int64), dyn_idx=dyn_idx, static_idx=[0])
 
 
 def test_revin_normalizes_all_dynamic_channels():
@@ -18,7 +18,7 @@ def test_revin_normalizes_all_dynamic_channels():
         [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]],
     ], dtype=np.float32)
     y = np.zeros((1,), dtype=np.float32)
-    ds = _SeriesDataset(X, y, dyn_idx=[0, 1], scaler="revin")
+    ds = _SeriesDataset(X, y, np.zeros((1, 0), dtype=np.int64), dyn_idx=[0, 1], scaler="revin")
     x, *_ = ds[0]
 
     tgt = X[0, :, 0]
@@ -27,3 +27,12 @@ def test_revin_normalizes_all_dynamic_channels():
     dyn2 = X[0, :, 1]
     expected1 = (dyn2 - dyn2.mean()) / dyn2.std()
     assert np.allclose(x[:, 1], expected1)
+
+
+def test_series_dataset_returns_static_codes():
+    X = np.zeros((2, 3, 1), dtype=np.float32)
+    y = np.zeros((2,), dtype=np.float32)
+    S = np.array([[1, 2], [3, 4]], dtype=np.int64)
+    ds = _SeriesDataset(X, y, S, dyn_idx=[0])
+    _, _, _, _, _, s = ds[1]
+    assert np.array_equal(s, S[1])

--- a/tests/test_pipeline_patchtst.py
+++ b/tests/test_pipeline_patchtst.py
@@ -28,17 +28,9 @@ def test_pipeline_patchtst(tmp_path):
 
     pt_path = workdir / "LGHackerton" / "models" / "patchtst" / "trainer.py"
     orig_pt = pt_path.read_text()
-    orig_pt = orig_pt.replace(
-        "X, Y, sids, dates = pp.build_patch_train(df_full)",
-        "X_dyn, X_stat, Y, sids, dates = pp.build_patch_train(df_full)\n        X = X_dyn",
-    )
-    orig_pt = orig_pt.replace(
-        "X, sids, dates = pp.build_patch_eval(df_full)",
-        "X_dyn, X_stat, sids, dates = pp.build_patch_eval(df_full)\n        X = X_dyn",
-    )
     stub = orig_pt + (
         "\n"
-        "def _train(self, X_train, y_train, series_ids, label_dates, cfg, preprocessors=None):\n"
+        "def _train(self, X_train, S_train, y_train, series_ids, label_dates, cfg, preprocessors=None):\n"
         "    import os\n"
         "    os.makedirs(self.model_dir, exist_ok=True)\n"
         "    open(os.path.join(self.model_dir, 'patchtst.pt'), 'wb').close()\n"
@@ -54,7 +46,7 @@ def test_pipeline_patchtst(tmp_path):
         "\n"
         "PatchTSTTrainer.load=lambda self, path: None\n"
         "\n"
-        "def _predict(self, X, sid_idx, dyn_idx=None, static_idx=None):\n"
+        "def _predict(self, X, S, sid_idx, dyn_idx=None, static_idx=None):\n"
         "    k = 1.0\n"
         "    eps = self.params.epsilon_leaky\n"
         "    import numpy as np\n"


### PR DESCRIPTION
## Summary
- extend `_SeriesDataset` to accept static feature matrix and return it alongside normalized dynamics
- wire static codes through PatchTST training and prediction data loaders
- update pipeline and tune utilities plus tests for new static input

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a90da94d8c83288badf9fe137bcd12