### PR TITLE
Ensure static code indices are valid for embeddings

### DIFF
--- a/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
+++ b/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
@@ -752,6 +752,7 @@ class SampleWindowizer:
                     continue
                 if static_cols:
                     stat_vals = g.loc[t, static_cols].values.astype(np.int64)
+                    stat_vals = np.clip(stat_vals + 1, 0, None)
                 else:
                     stat_vals = np.empty((0,), dtype=np.int64)
                 X_dyn_list.append(dyn_window)
@@ -815,6 +816,7 @@ class SampleWindowizer:
             dyn_window = g.loc[len(g) - self.L: len(g) - 1, dynamic_cols].values.astype(float)
             if static_cols:
                 stat_vals = g.loc[len(g) - 1, static_cols].values.astype(np.int64)
+                stat_vals = np.clip(stat_vals + 1, 0, None)
             else:
                 stat_vals = np.empty((0,), dtype=np.int64)
             X_dyn_list.append(dyn_window)

--- a/tests/test_patch_windowizer.py
+++ b/tests/test_patch_windowizer.py
@@ -26,7 +26,7 @@ def test_patch_windowizer_dynamic_static():
                 SALES_COL: float(i + 1),
                 SALES_FILLED_COL: float(i + 1),
                 "feat_dyn": float(i),
-                "feat_static": 42.0,
+                "feat_static": 1,
             }
         )
     df = pd.DataFrame(records)
@@ -35,20 +35,20 @@ def test_patch_windowizer_dynamic_static():
     static_cols = ["feat_static"]
 
     win = SampleWindowizer(lookback=3, horizon=2)
-    X_dyn, X_stat, Y, sids, dates, dyn_idx, stat_idx = win.build_patch_train(
+    X_dyn, S, Y, sids, dates, dyn_idx, stat_idx = win.build_patch_train(
         df, feature_cols, static_cols
     )
 
     assert X_dyn.shape == (1, 3, 2)
     expected_dyn = df.loc[0:2, [SALES_FILLED_COL, "feat_dyn"]].values
     np.testing.assert_allclose(X_dyn[0], expected_dyn)
-    np.testing.assert_array_equal(X_stat[0], np.array([42], dtype=np.int64))
+    np.testing.assert_array_equal(S[0], np.array([2], dtype=np.int64))
     np.testing.assert_allclose(Y[0], df.loc[3:4, SALES_COL].values)
     assert win.dynamic_idx[SALES_FILLED_COL] == 0
     assert win.dynamic_idx["feat_dyn"] == 1
     assert win.static_idx["feat_static"] == 0
 
-    X_eval_dyn, X_eval_stat, sids_eval, dates_eval, dyn_idx_e, stat_idx_e = win.build_patch_eval(
+    X_eval_dyn, S_eval, sids_eval, dates_eval, dyn_idx_e, stat_idx_e = win.build_patch_eval(
         df, feature_cols, static_cols
     )
     assert dyn_idx == dyn_idx_e
@@ -56,7 +56,7 @@ def test_patch_windowizer_dynamic_static():
     assert X_eval_dyn.shape == (1, 3, 2)
     expected_eval_dyn = df.loc[2:4, [SALES_FILLED_COL, "feat_dyn"]].values
     np.testing.assert_allclose(X_eval_dyn[0], expected_eval_dyn)
-    np.testing.assert_array_equal(X_eval_stat[0], np.array([42], dtype=np.int64))
+    np.testing.assert_array_equal(S_eval[0], np.array([2], dtype=np.int64))
     assert sids_eval[0] == "A"
     assert dates_eval.shape == (1,)
 
@@ -64,7 +64,7 @@ def test_patch_windowizer_dynamic_static():
 def test_patch_windowizer_static_multi_series():
     dates = pd.date_range("2020-01-01", periods=4, freq="D")
     records = []
-    for sid, s_val in [("A", 1.0), ("B", 2.0)]:
+    for sid, s_val in [("A", 0), ("B", 1)]:
         for i, d in enumerate(dates):
             records.append(
                 {
@@ -81,10 +81,34 @@ def test_patch_windowizer_static_multi_series():
     static_cols = ["feat_static"]
 
     win = SampleWindowizer(lookback=2, horizon=1)
-    X_dyn, X_stat, Y, sids, dates, dyn_idx, stat_idx = win.build_patch_train(
+    X_dyn, S, Y, sids, dates, dyn_idx, stat_idx = win.build_patch_train(
         df, feature_cols, static_cols
     )
     static_idx = stat_idx["feat_static"]
-    for stat_vals, sid in zip(X_stat, sids):
+    for stat_vals, sid in zip(S, sids):
         expected = 1 if sid == "A" else 2
         np.testing.assert_array_equal(stat_vals[static_idx], expected)
+
+
+def test_static_codes_non_negative_with_unknown():
+    dates = pd.date_range("2020-01-01", periods=5, freq="D")
+    records = []
+    for i, d in enumerate(dates):
+        records.append(
+            {
+                SERIES_COL: "A",
+                DATE_COL: d,
+                SALES_COL: float(i + 1),
+                SALES_FILLED_COL: float(i + 1),
+                "feat_dyn": float(i),
+                "feat_static": 0 if i < 3 else -1,
+            }
+        )
+    df = pd.DataFrame(records)
+    feature_cols = ["feat_dyn", "feat_static"]
+    static_cols = ["feat_static"]
+    win = SampleWindowizer(lookback=3, horizon=1)
+    _, S, _, _, _, _, _ = win.build_patch_train(df, feature_cols, static_cols)
+    assert S.shape == (2, 1)
+    assert np.array_equal(S[:, 0], np.array([1, 0], dtype=np.int64))
+    assert S.min() >= 0

--- a/tests/test_patchtst_series_dataset.py
+++ b/tests/test_patchtst_series_dataset.py
@@ -1,5 +1,9 @@
 import numpy as np
 import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from LGHackerton.models.patchtst.trainer import _SeriesDataset
 


### PR DESCRIPTION
## Summary
- Shift static categorical codes to non-negative indices for PatchTST windows
- Update windowizer and dataset tests for separated static codes
- Add regression test ensuring unknown categories map to valid embedding indices

## Testing
- `pytest tests/test_patch_windowizer.py -q`
- `pytest tests/test_patchtst_series_dataset.py -q`
- `pytest tests/test_patchtst_feature_filter.py -q`
- `pytest tests/test_pipeline_patchtst.py::test_pipeline_patchtst -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9282e47d0832897cd179ee88b9c82