### PR TITLE
Simplify PatchTST patch extraction

### DIFF
--- a/LGHackerton/models/patchtst/trainer.py
+++ b/LGHackerton/models/patchtst/trainer.py
@@ -326,8 +326,7 @@ if TORCH_OK:
 
         def forward(self, x, sid_idx=None, static_codes=None):
             B, L, C = x.shape
-            p = x.unfold(1, self.patch_len, self.stride)  # (B, n_patches, patch_len, C)
-            p = p.permute(0, 1, 3, 2).contiguous()  # (B, n_patches, C, patch_len)
+            p = x.unfold(1, self.patch_len, self.stride).contiguous()  # (B, n_patches, C, patch_len)
             z = self.proj(p)  # (B, n_patches, C, d_model)
             if self.id_embed is not None and sid_idx is not None:
                 e = self.id_embed(sid_idx)


### PR DESCRIPTION
## Summary
- Avoid unnecessary permutation when extracting patches in `PatchTSTNet.forward`
- Keep unfolding output contiguous and reshape correctly through transformer blocks

## Testing
- `python - <<'PY'
import torch
from LGHackerton.models.patchtst.trainer import PatchTSTNet
net = PatchTSTNet(L=10, H=5, d_model=8, n_heads=2, depth=1, patch_len=4, stride=1, dropout=0.1,
                  id_embed_dim=0, num_series=0, input_dim=3, static_cardinalities=None,
                  static_emb_dim=16, channel_fusion='mean')
x = torch.randn(2,10,3)
with torch.no_grad():
    p_clf, mu_raw, kappa_raw = net(x)
print(p_clf.shape, mu_raw.shape, kappa_raw.shape)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a99c34d700832892e01b478a604642