### PR TITLE
Document PatchTST channel fusion options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,4 +86,5 @@ consistent formatting and handle any missing or duplicate entries.
 - [Callbacks](docs/callbacks.md)
 - [Hyperparameter Tuning](docs/tuning.md)
 - [Model & Tuner Registries](docs/registry_tuner.md)
+- [PatchTST Model](docs/patchtst.md)
 

--- a/docs/patchtst.md
+++ b/docs/patchtst.md
@@ -1,0 +1,30 @@
+# PatchTST Model
+
+PatchTST consumes tensors shaped `(B, L, C)` where `B` is the batch size, `L` the input length and `C` the number of channels. Each channel is unfolded into patches of length `patch_len` and passed through a linear layer `nn.Linear(patch_len, d_model)` so patches are projected independently before fusion.
+
+## Channel fusion
+
+The `channel_fusion` hyperparameter controls how channel embeddings are merged:
+
+- `attention` – a learned query attends across channels.
+- `linear` – a linear layer produces softmax weights for each channel.
+- `mean` – simple arithmetic mean over channel embeddings.
+
+## Late fusion example
+
+```python
+import torch
+from LGHackerton.models.patchtst.trainer import PatchTSTTrainer
+
+net = PatchTSTTrainer.PatchTSTNet(
+    L=96, H=24, d_model=128, n_heads=8, depth=2,
+    patch_len=16, stride=8, dropout=0.2,
+    channel_fusion="attention",
+)
+
+x = torch.randn(4, 96, 5)  # (B, L, C)
+p_clf, mu_raw, kappa_raw = net(x)
+```
+
+Each channel is patched and projected separately; the resulting embeddings are fused
+late using the configured strategy before producing classification and regression outputs.


### PR DESCRIPTION
## Summary
- Document PatchTST tensor shape `(B, L, C)` and per-channel patch projection
- Explain `channel_fusion` options (`attention`, `linear`, `mean`) and add late fusion usage example
- Link new PatchTST model doc from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9a0b6a9f88328add968b13f6730d1