### PR TITLE
Format series IDs before missing checks

### DIFF
--- a/LGHackerton/postprocess/convert.py
+++ b/LGHackerton/postprocess/convert.py
@@ -106,6 +106,11 @@ def aggregate_predictions(
     if np.isnan(merged["yhat_ens"]).any():
         logging.warning("Some predictions are missing after aggregation")
 
+    # Convert series ids to match the sample submission format before
+    # performing consistency checks against the sample file. The sample
+    # submission uses single underscores instead of the "::" separator.
+    merged.loc[:, "series_id"] = merged["series_id"].str.replace("::", "_", n=1)
+
     _missing_checks(merged)
 
     return merged

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -17,7 +17,10 @@ def _make_df(col_name: str, values):
 def test_single_model_identity():
     df = _make_df("yhat_patch", [1.0, 2.0])
     agg = aggregate_predictions([df])
-    expected = df.rename(columns={"yhat_patch": "yhat_ens"})[["series_id", "date", "yhat_ens"]]
+    expected = df.rename(columns={"yhat_patch": "yhat_ens"})[
+        ["series_id", "date", "yhat_ens"]
+    ]
+    expected["series_id"] = expected["series_id"].str.replace("::", "_", n=1)
     pd.testing.assert_frame_equal(agg.sort_index(axis=1), expected.sort_index(axis=1))
 
 

--- a/tests/test_tuner_validation.py
+++ b/tests/test_tuner_validation.py
@@ -23,6 +23,19 @@ def test_patchtst_validate_params(dummy_ctx):
     tuner = PatchTSTTuner(pp, df, cfg)
     params = PatchTSTParams()
     params_dict = params.__dict__.copy()
+    # Ensure parameters fall within the search space for fields not under test
+    s = tuner.search_space
+    stride_val = s.stride[0] if isinstance(s.stride, tuple) else s.stride
+    params_dict.update(
+        {
+            "d_model": s.d_model[0],
+            "n_heads": s.n_heads[0],
+            "patch_len": s.patch_len[0],
+            "stride": stride_val,
+            "id_embed_dim": s.id_embed_dim[0],
+            "batch_size": s.batch_size[0],
+        }
+    )
     params_missing = params_dict.copy()
     params_missing.pop("patch_len")
     with pytest.raises(TypeError, match="Missing field: patch_len"):


### PR DESCRIPTION
## Summary
- Convert colon-separated series IDs to underscores before running missing checks
- Adjust tests for new series ID format and valid tuner parameter defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9fb44c8fc8328a6f1145b009aa6d0