### PR TITLE
feat: add threshold gating for patchtst

### DIFF
--- a/LGHackerton/models/patchtst/__init__.py
+++ b/LGHackerton/models/patchtst/__init__.py
@@ -11,6 +11,7 @@ from .train import (
     trunc_nb_nll,
     focal_loss,
     combine_predictions,
+    combine_predictions_thresholded,
     weighted_smape_oof,
 )
 
@@ -20,5 +21,6 @@ __all__ = [
     "trunc_nb_nll",
     "focal_loss",
     "combine_predictions",
+    "combine_predictions_thresholded",
     "weighted_smape_oof",
 ]


### PR DESCRIPTION
## Summary
- add `combine_predictions_thresholded` to support soft/hard gating
- extend PatchTST trainer with tau/T params, per-series calibration, and saved tau_map
- apply thresholded gating during training, validation, and prediction

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa08f76d788328828706a87577b155