### PR TITLE
Add thresholded combination for PatchTST

### DIFF
--- a/LGHackerton/models/patchtst/__init__.py
+++ b/LGHackerton/models/patchtst/__init__.py
@@ -11,7 +11,9 @@ from .train import (
     trunc_nb_nll,
     focal_loss,
     combine_predictions,
+    combine_predictions_thresholded,
     weighted_smape_oof,
+    weighted_smape_oof_thresholded,
 )
 
 __all__ = [
@@ -20,5 +22,7 @@ __all__ = [
     "trunc_nb_nll",
     "focal_loss",
     "combine_predictions",
+    "combine_predictions_thresholded",
     "weighted_smape_oof",
+    "weighted_smape_oof_thresholded",
 ]

--- a/tests/test_patchtst_loss_helpers.py
+++ b/tests/test_patchtst_loss_helpers.py
@@ -8,9 +8,11 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from LGHackerton.models.patchtst import (
     combine_predictions,
+    combine_predictions_thresholded,
     focal_loss,
     trunc_nb_nll,
     weighted_smape_oof,
+    weighted_smape_oof_thresholded,
 )
 
 
@@ -24,7 +26,38 @@ def test_weighted_smape_oof_accepts_tensor_kappa():
     assert loss.ndim == 0
 
 
+def test_weighted_smape_oof_thresholded_accepts_tensor_kappa():
+    """weighted_smape_oof_thresholded should handle per-sample kappa tensors."""
+    y_true = torch.tensor([0.0, 1.0])
+    clf_prob = torch.tensor([0.2, 0.8])
+    mu = torch.tensor([0.3, 0.5])
+    kappa = torch.tensor([1.0, 2.0])
+    loss = weighted_smape_oof_thresholded(y_true, p=clf_prob, mu=mu, kappa=kappa, tau=0.5)
+    assert loss.ndim == 0
+
+
+def test_combine_predictions_thresholded_gate_behaviour():
+    """Hard and soft gates should behave as expected."""
+    p = torch.tensor([0.3, 0.7])
+    logits = torch.logit(p)
+    mu = torch.tensor([1.0, 2.0])
+    kappa = torch.tensor([1.0, 1.0])
+    hard = combine_predictions_thresholded(p=p, mu=mu, kappa=kappa, tau=0.5)
+    soft = combine_predictions_thresholded(logits=logits, mu=mu, kappa=kappa, tau=0.5, temperature=1.0)
+    expected_hard = torch.tensor([0.0, 3.0])
+    expected_soft = torch.tensor([0.6, 2.1])
+    assert torch.allclose(hard, expected_hard)
+    assert torch.allclose(soft, expected_soft)
+
+
 def test_patchtst_exports_loss_helpers():
     """The patchtst package should expose utility functions for external use."""
-    for fn in (trunc_nb_nll, focal_loss, combine_predictions, weighted_smape_oof):
+    for fn in (
+        trunc_nb_nll,
+        focal_loss,
+        combine_predictions,
+        combine_predictions_thresholded,
+        weighted_smape_oof,
+        weighted_smape_oof_thresholded,
+    ):
         assert callable(fn)


### PR DESCRIPTION
## Summary
- add gating-based `combine_predictions_thresholded` and helper `weighted_smape_oof_thresholded`
- export new prediction helpers from PatchTST module
- test thresholded gating behaviour and utility exports

## Testing
- `pytest tests/test_patchtst_loss_helpers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa6b426ae88328b29bc2b96109fb1a