### PR TITLE
Handle logits in PatchTST classifier head

### DIFF
--- a/docs/patchtst.md
+++ b/docs/patchtst.md
@@ -23,7 +23,8 @@ net = PatchTSTTrainer.PatchTSTNet(
 )
 
 x = torch.randn(4, 96, 5)  # (B, L, C)
-p_clf, mu_raw, kappa_raw = net(x)
+logits, mu_raw, kappa_raw = net(x)
+prob = torch.sigmoid(logits)
 ```
 
 Each channel is patched and projected separately; the resulting embeddings are fused


### PR DESCRIPTION
## Summary
- Return raw logits from PatchTST's classifier head instead of probabilities
- Update training, validation, and prediction loops to apply `torch.sigmoid` where needed
- Document how to derive probabilities from classifier logits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa6c09151c8328a68f3a20a058e30a