### PR TITLE
Refactor PatchTST gating with temperature annealing

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -42,7 +42,7 @@ PATCH_PARAMS = dict(
     lr=1e-3, weight_decay=1e-4, batch_size=256,
     max_epochs=200, patience=20,
     lambda_nb=1.0, lambda_clf=1.0, lambda_s=0.05,
-    gamma=2.0, alpha=0.5, epsilon_leaky=0.0,
+    gamma=2.0, alpha=0.5, tau=0.5,
     num_workers=0,
 )
 TRAIN_CFG = dict(


### PR DESCRIPTION
## Summary
- introduce linear temperature annealing and thresholded gating for PatchTST
- remove epsilon_leaky usage and add configurable tau threshold
- update configuration and tests for new gating behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa6d3c4c3c83289d7f1e2521571b71