### PR TITLE
Expose lambda_smooth config for PatchTST

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -41,7 +41,7 @@ PATCH_PARAMS = dict(
     id_embed_dim=16,
     lr=1e-3, weight_decay=1e-4, batch_size=256,
     max_epochs=200, patience=20,
-    lambda_nb=1.0, lambda_s=0.05,
+    lambda_nb=1.0, lambda_s=0.05, lambda_smooth=0.0,
     tau=0.5,
     num_workers=0,
 )

--- a/tests/test_params_lambda_smooth.py
+++ b/tests/test_params_lambda_smooth.py
@@ -1,0 +1,16 @@
+from LGHackerton.utils import params as params_mod
+from LGHackerton.models.patchtst.trainer import PatchTSTParams
+
+
+def test_load_best_params_includes_lambda_smooth(tmp_path, monkeypatch):
+    monkeypatch.setattr(params_mod, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(params_mod, "OPTUNA_DIR", tmp_path / "optuna")
+
+    params_dict, input_len = params_mod.load_best_params("patchtst")
+
+    assert input_len is None
+    assert "lambda_smooth" in params_dict
+    assert params_dict["lambda_smooth"] == 0.0
+
+    params_obj = PatchTSTParams(**params_dict)
+    assert params_obj.lambda_smooth == params_dict["lambda_smooth"]


### PR DESCRIPTION
## Summary
- expose `lambda_smooth` in default PatchTST parameters
- ensure parameter loader returns `lambda_smooth` and is accepted by `PatchTSTParams`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa9498a2f08328a1761b46badfe8ec