### PR TITLE
Validate positive counts for trunc_nb_nll

### DIFF
--- a/LGHackerton/models/patchtst/train.py
+++ b/LGHackerton/models/patchtst/train.py
@@ -140,6 +140,8 @@ def trunc_nb_nll(y: Tensor, mu: Tensor, kappa: Tensor) -> Tensor:
     """
 
     y = y.to(mu.dtype)
+    if (y <= 0).any():
+        raise ValueError("trunc_nb_nll requires y > 0")
     kappa = torch.clamp(
         torch.as_tensor(kappa, dtype=mu.dtype, device=mu.device), min=1e-8
     )

--- a/tests/test_patchtst_loss_helpers.py
+++ b/tests/test_patchtst_loss_helpers.py
@@ -2,6 +2,7 @@ import pathlib
 import sys
 
 import torch
+import pytest
 
 # Add project root to sys.path for module imports
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
@@ -73,3 +74,12 @@ def test_patchtst_exports_loss_helpers():
         weighted_smape_oof_thresholded,
     ):
         assert callable(fn)
+
+
+def test_trunc_nb_nll_requires_strictly_positive_targets():
+    """trunc_nb_nll should raise if any target is non-positive."""
+    y = torch.tensor([1.0, 0.0])
+    mu = torch.tensor([0.3, 0.5])
+    kappa = torch.tensor([1.0, 2.0])
+    with pytest.raises(ValueError, match="trunc_nb_nll requires y > 0"):
+        trunc_nb_nll(y, mu, kappa)


### PR DESCRIPTION
## Summary
- raise an error in `trunc_nb_nll` when targets contain non-positive values
- add regression test to ensure negative or zero counts are rejected

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aacd740ca08328a5a0b59ba8b9e3f3