### PR TITLE
Clip negative sales before capping

### DIFF
--- a/tests/test_negative_sales_clip.py
+++ b/tests/test_negative_sales_clip.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from LGHackerton.preprocess.preprocess_pipeline_v1_1 import (
+    Preprocessor,
+    RAW_DATE,
+    RAW_KEY,
+    RAW_QTY,
+    SALES_COL,
+    SALES_FILLED_COL,
+)
+
+
+def test_negative_sales_clipped():
+    df = pd.DataFrame({
+        RAW_DATE: pd.to_datetime(["2024-01-01", "2024-01-01"]),
+        RAW_KEY: ["shop1_menu", "shop2_menu"],
+        RAW_QTY: [-5, 3],
+    })
+    pp = Preprocessor()
+    out = pp.fit_transform_train(df)
+    assert (out[SALES_COL] >= 0).all()
+    assert (out[SALES_FILLED_COL] >= 0).all()
+


### PR DESCRIPTION
## Summary
- Clip negative sales to zero before outlier capping and transformation
- Provide helper `_clip_negative` for logging negative counts
- Add regression test ensuring preprocessing removes negative sales

## Testing
- `pytest tests/test_negative_sales_clip.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad46d80c883288e5e07d62c76a9eb