### PR TITLE
Add configurable gradient clipping to PatchTST

### DIFF
--- a/LGHackerton/config/default.py
+++ b/LGHackerton/config/default.py
@@ -39,7 +39,7 @@ PATCH_PARAMS = dict(
     d_model=128, n_heads=8, depth=4,
     patch_len=4, stride=1, dropout=0.1,
     id_embed_dim=16,
-    lr=1e-3, weight_decay=1e-4, batch_size=256,
+    lr=1e-3, weight_decay=1e-4, grad_clip=1.0, batch_size=256,
     max_epochs=200, patience=20,
     lambda_nb=1.0, lambda_s=0.05, lambda_smooth=0.0,
     tau=0.5,


### PR DESCRIPTION
## Summary
- allow configurable gradient clipping via new `grad_clip` parameter in `PatchTSTParams`
- apply `torch.nn.utils.clip_grad_norm_` during training and log selected value
- expose default `grad_clip` setting in configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaed9e39e083288cba88f925eaceb4