### PR TITLE
Keep day-of-week column for cyclical mode

### DIFF
--- a/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
+++ b/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
@@ -326,7 +326,6 @@ class CalendarFeatureMaker:
         if self.dow_mode == "cyclical":
             d["dow_sin"] = np.sin(2 * np.pi * d["dow"] / 7)
             d["dow_cos"] = np.cos(2 * np.pi * d["dow"] / 7)
-            d.drop(columns=["dow"], inplace=True)
 
         # base calendar categories
         if self.cyclical:

--- a/tests/test_calendar_feature_maker.py
+++ b/tests/test_calendar_feature_maker.py
@@ -72,7 +72,7 @@ def test_dow_modes(mode):
     out = CalendarFeatureMaker(dow_mode=mode).fit(df).transform(df)
     assert "day" not in out.columns
     if mode == "cyclical":
-        assert "dow" not in out.columns
+        assert "dow" in out.columns
         assert {"dow_sin", "dow_cos"}.issubset(out.columns)
     else:
         assert "dow" in out.columns


### PR DESCRIPTION
## Summary
- Keep `dow` column when using cyclical day-of-week features
- Update calendar feature tests for new behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaf38b40488328b58ea8400b07c55c