### PR TITLE
Drop dow feature in cyclical calendar mode

### DIFF
--- a/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
+++ b/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
@@ -949,6 +949,13 @@ class Preprocessor:
             self.rich.fit(df)
             return self.rich.transform(df)
 
+        def _drop_dow(df: pd.DataFrame) -> pd.DataFrame:
+            return (
+                df.drop(columns=["dow"], errors="ignore")
+                if self.calendar.dow_mode == "cyclical"
+                else df
+            )
+
         def _encode(df: pd.DataFrame) -> pd.DataFrame:
             self.encoder.fit(df)
             return self.encoder.transform(df)
@@ -990,6 +997,7 @@ class Preprocessor:
             ("missing_outlier", _missing_outlier),
             ("strict_feats", _strict_feats),
             ("rich_lookup", _rich_lookup),
+            ("drop_dow", _drop_dow),
             ("encoder", _encode),
             ("drop_low_var", _drop_low_var),
             ("feature_cols", _feature_cols),
@@ -1011,6 +1019,13 @@ class Preprocessor:
         self.guard.set_scope("eval")
         self.guard.assert_scope({"eval"})
 
+        def _drop_dow(df: pd.DataFrame) -> pd.DataFrame:
+            return (
+                df.drop(columns=["dow"], errors="ignore")
+                if self.calendar.dow_mode == "cyclical"
+                else df
+            )
+
         steps = [
             ("schema", lambda df: self.schema.transform(df, allow_new=False)),
             ("continuity", self.cont_fix.transform),
@@ -1018,8 +1033,12 @@ class Preprocessor:
             ("missing_outlier", self.missing_outlier.transform),
             ("strict_feats", self.strict_feats.transform),
             ("rich_lookup", self.rich.transform),
+            ("drop_dow", _drop_dow),
             ("encoder", self.encoder.transform),
-            ("drop_low_var", lambda df: df.drop(columns=self.low_var_cols, errors="ignore")),
+            (
+                "drop_low_var",
+                lambda df: df.drop(columns=self.low_var_cols, errors="ignore"),
+            ),
         ]
 
         df = df_eval_raw

--- a/tests/test_calendar_feature_maker.py
+++ b/tests/test_calendar_feature_maker.py
@@ -12,6 +12,9 @@ from LGHackerton.preprocess.preprocess_pipeline_v1_1 import (  # noqa: E402
     DATE_COL,
     SHOP_COL,
     Preprocessor,
+    RAW_DATE,
+    RAW_KEY,
+    RAW_QTY,
 )
 
 
@@ -126,3 +129,36 @@ def test_preprocessor_cyclical_option_controls_dummies():
 
     assert not dummy(out_default.columns)
     assert dummy(out_dum.columns)
+
+
+def test_preprocessor_drops_dow_when_cyclical():
+    df = pd.DataFrame(
+        {
+            RAW_DATE: pd.to_datetime(
+                ["2024-01-01", "2024-01-01", "2024-01-02", "2024-01-02"]
+            ),
+            RAW_KEY: ["shop1_menu1", "shop2_menu2", "shop1_menu1", "shop2_menu2"],
+            RAW_QTY: [1, 2, 3, 4],
+        }
+    )
+    pp = Preprocessor()
+    out = pp.fit_transform_train(df)
+    assert "dow" not in out.columns
+    assert "dow" not in pp.feature_cols
+
+
+def test_preprocessor_keeps_dow_when_not_cyclical():
+    df = pd.DataFrame(
+        {
+            RAW_DATE: pd.to_datetime(
+                ["2024-01-01", "2024-01-01", "2024-01-02", "2024-01-02"]
+            ),
+            RAW_KEY: ["shop1_menu1", "shop2_menu2", "shop1_menu1", "shop2_menu2"],
+            RAW_QTY: [1, 2, 3, 4],
+        }
+    )
+    pp = Preprocessor()
+    pp.calendar.dow_mode = "integer"
+    out = pp.fit_transform_train(df)
+    assert "dow" in out.columns
+    assert "dow" in pp.feature_cols


### PR DESCRIPTION
## Summary
- Remove raw `dow` column when calendar uses cyclical encoding
- Ensure evaluation pipeline also strips `dow`
- Add tests covering `dow` dropping for cyclical mode and retention otherwise

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaf49ea1d483288dd157d10914126f