### PR TITLE
Relax PatchTST tuner pruning

### DIFF
--- a/LGHackerton/tuning/patchtst.py
+++ b/LGHackerton/tuning/patchtst.py
@@ -234,7 +234,7 @@ class PatchTSTTuner(HyperparameterTuner):
                 else 0.0,
             )
 
-        pruner = PatientPruner(MedianPruner(n_warmup_steps=5), patience=2)
+        pruner = PatientPruner(MedianPruner(n_warmup_steps=12), patience=4)
         study = optuna.create_study(
             direction="minimize", sampler=sampler, pruner=pruner
         )


### PR DESCRIPTION
## Summary
- soften PatchTST Optuna pruner by increasing warmup to 12 steps and patience to 4

## Testing
- `pytest`
- `python LGHackerton/tune.py --patch --n-trials 1 --timeout 60` *(killed: container memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_68ab23714d708328933228cd63e4a047