### PR TITLE
Preserve intermittency features for PatchTST

### DIFF
--- a/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
+++ b/LGHackerton/preprocess/preprocess_pipeline_v1_1.py
@@ -904,8 +904,6 @@ class Preprocessor:
         drop = {
             "is_priority_outlet",
             "is_promo",
-            "zero_ratio_28",
-            "days_since_last_sale",
             "series_code",
             "series_cv",
         }

--- a/docs/patchtst.md
+++ b/docs/patchtst.md
@@ -41,3 +41,10 @@ prob = torch.sigmoid(logits)
 
 Each channel is patched and projected separately; the resulting embeddings are fused
 late using the configured strategy before producing classification and regression outputs.
+
+## Intermittency features
+
+`zero_ratio_28` and `days_since_last_sale` describe demand sparsity patterns.  They
+are useful signals for PatchTST because the model can attend to prolonged zero-sales
+stretches when forming patches.  Unlike other preprocessing variants that drop these
+columns, PatchTST keeps them to better model intermittent demand.

--- a/tests/test_patchtst_feature_filter.py
+++ b/tests/test_patchtst_feature_filter.py
@@ -83,10 +83,10 @@ def test_patchtst_intermittency_features():
     # Compute PatchTST feature lists
     pp._compute_patch_features()
 
-    # Only zero_run_len should remain among intermittency features
+    # All intermittency indicators should be retained
     assert "zero_run_len" in pp.patch_feature_cols
-    assert "zero_ratio_28" not in pp.patch_feature_cols
-    assert "days_since_last_sale" not in pp.patch_feature_cols
+    assert "zero_ratio_28" in pp.patch_feature_cols
+    assert "days_since_last_sale" in pp.patch_feature_cols
 
 
 def test_patchtst_drop_series_code():


### PR DESCRIPTION
## Summary
- Retain `zero_ratio_28` and `days_since_last_sale` in PatchTST feature set by removing them from the preprocessing drop list.
- Update PatchTST feature filter test to expect these intermittency features.
- Document rationale for keeping sparsity indicators in PatchTST.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab38c11a748328bb04f0a566ebae0a