### PR TITLE
Add long-horizon summary features to PatchTST

### DIFF
--- a/LGHackerton/train.py
+++ b/LGHackerton/train.py
@@ -160,7 +160,7 @@ def run_training(ctx: PipelineContext) -> None:
     except AttributeError as e:
         raise RuntimeError(f"{ctx.model_name} build_dataset not implemented") from e
     try:
-        X_train, S_train, y_train, series_ids, label_dates = build_dataset(
+        X_train, S_train, M_train, y_train, series_ids, label_dates = build_dataset(
             ctx.preprocessor, ctx.df_full, ctx.input_len
         )
     except NotImplementedError as e:
@@ -184,6 +184,7 @@ def run_training(ctx: PipelineContext) -> None:
     trainer.train(
         X_train,
         S_train,
+        M_train,
         y_train,
         series_ids,
         label_dates,

--- a/LGHackerton/tune.py
+++ b/LGHackerton/tune.py
@@ -101,7 +101,7 @@ def run_patchtst_grid_search(cfg_path: str | Path) -> None:
 
     device = "cuda" if torch and torch.cuda.is_available() else "cpu"
     results: List[dict[str, Any]] = []
-    dataset_cache: dict[int, tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = {}
+    dataset_cache: dict[int, tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = {}
 
     # Prebuild datasets for each unique input length
     for inp in input_lens:
@@ -111,7 +111,7 @@ def run_patchtst_grid_search(cfg_path: str | Path) -> None:
 
     # Iterate over grid while reusing cached datasets
     for inp in input_lens:
-        X, S, y, series_ids, label_dates = dataset_cache[inp]
+        X, S, M, y, series_ids, label_dates = dataset_cache[inp]
         for patch, lr, scaler in itertools.product(patch_lens, lrs, scalers):
             if inp % patch != 0:
                 continue
@@ -127,7 +127,7 @@ def run_patchtst_grid_search(cfg_path: str | Path) -> None:
                 trainer = PatchTSTTrainer(
                     params=params, L=inp, H=H, model_dir=cfg.model_dir, device=device
                 )
-                trainer.train(X, S, y, series_ids, label_dates, cfg)
+                trainer.train(X, S, M, y, series_ids, label_dates, cfg)
                 oof = trainer.get_oof()
                 outlets = oof["series_id"].str.split("::").str[0].values
                 val_w = weighted_smape_np(

--- a/LGHackerton/tuning/patchtst.py
+++ b/LGHackerton/tuning/patchtst.py
@@ -298,19 +298,20 @@ class PatchTSTTuner(HyperparameterTuner):
                 input_len = trial.suggest_categorical("input_len", input_lens)
                 if input_len not in self._dataset_cache:
                     self.pp.windowizer = SampleWindowizer(lookback=input_len, horizon=H)
-                    X, S, y, series_ids, label_dates = self.pp.build_patch_train(self.df)
+                    X, S, M, y, series_ids, label_dates = self.pp.build_patch_train(self.df)
                     dyn_idx = getattr(self.pp, "patch_dynamic_idx", {}).copy()
                     stat_idx = getattr(self.pp, "patch_static_idx", {}).copy()
                     self._dataset_cache[input_len] = (
                         X,
                         S,
+                        M,
                         y,
                         series_ids,
                         label_dates,
                         dyn_idx,
                         stat_idx,
                     )
-                X, S, y, series_ids, label_dates, dyn_idx, stat_idx = self._dataset_cache[input_len]
+                X, S, M, y, series_ids, label_dates, dyn_idx, stat_idx = self._dataset_cache[input_len]
                 # Reassign channel index maps to ensure they reflect the cached
                 # dataset's indices even if downstream steps mutate them.
                 self.pp.patch_dynamic_idx = dyn_idx.copy()
@@ -364,6 +365,7 @@ class PatchTSTTuner(HyperparameterTuner):
                 trainer.train(
                     X,
                     S,
+                    M,
                     y,
                     series_ids,
                     label_dates,

--- a/LGHackerton/tuning/tft.py
+++ b/LGHackerton/tuning/tft.py
@@ -56,7 +56,9 @@ class TFTTuner(HyperparameterTuner):
         """Construct training tensors for TFT."""
 
         if self._dataset is None:
-            self._dataset = self.pp.build_patch_train(self.df)
+            X, S, M, y, series_ids, label_dates = self.pp.build_patch_train(self.df)
+            # TFT expects dynamic inputs X, targets y and identifiers
+            self._dataset = (X, y, series_ids, label_dates)
         return self._dataset
 
     # ------------------------------------------------------------------

--- a/tests/test_patch_windowizer.py
+++ b/tests/test_patch_windowizer.py
@@ -35,7 +35,7 @@ def test_patch_windowizer_dynamic_static():
     static_cols = ["feat_static"]
 
     win = SampleWindowizer(lookback=3, horizon=2)
-    X_dyn, S, Y, sids, dates, dyn_idx, stat_idx = win.build_patch_train(
+    X_dyn, S, M, Y, sids, dates, dyn_idx, stat_idx = win.build_patch_train(
         df, feature_cols, static_cols
     )
 
@@ -48,7 +48,7 @@ def test_patch_windowizer_dynamic_static():
     assert win.dynamic_idx["feat_dyn"] == 1
     assert win.static_idx["feat_static"] == 0
 
-    X_eval_dyn, S_eval, sids_eval, dates_eval, dyn_idx_e, stat_idx_e = win.build_patch_eval(
+    X_eval_dyn, S_eval, M_eval, sids_eval, dates_eval, dyn_idx_e, stat_idx_e = win.build_patch_eval(
         df, feature_cols, static_cols
     )
     assert dyn_idx == dyn_idx_e
@@ -81,7 +81,7 @@ def test_patch_windowizer_static_multi_series():
     static_cols = ["feat_static"]
 
     win = SampleWindowizer(lookback=2, horizon=1)
-    X_dyn, S, Y, sids, dates, dyn_idx, stat_idx = win.build_patch_train(
+    X_dyn, S, M, Y, sids, dates, dyn_idx, stat_idx = win.build_patch_train(
         df, feature_cols, static_cols
     )
     static_idx = stat_idx["feat_static"]
@@ -108,7 +108,7 @@ def test_static_codes_non_negative_with_unknown():
     feature_cols = ["feat_dyn", "feat_static"]
     static_cols = ["feat_static"]
     win = SampleWindowizer(lookback=3, horizon=1)
-    _, S, _, _, _, _, _ = win.build_patch_train(df, feature_cols, static_cols)
+    _, S, _, _, _, _, _, _ = win.build_patch_train(df, feature_cols, static_cols)
     assert S.shape == (2, 1)
     assert np.array_equal(S[:, 0], np.array([1, 0], dtype=np.int64))
     assert S.min() >= 0

--- a/tests/test_patchtst_series_dataset.py
+++ b/tests/test_patchtst_series_dataset.py
@@ -38,5 +38,5 @@ def test_series_dataset_returns_static_codes():
     y = np.zeros((2,), dtype=np.float32)
     S = np.array([[1, 2], [3, 4]], dtype=np.int64)
     ds = _SeriesDataset(X, y, S, dyn_idx=[0])
-    _, _, _, _, _, s = ds[1]
+    _, _, _, _, _, s, _ = ds[1]
     assert np.array_equal(s, S[1])

--- a/tests/test_pipeline_patchtst.py
+++ b/tests/test_pipeline_patchtst.py
@@ -31,7 +31,7 @@ def test_pipeline_patchtst(tmp_path):
     orig_pt = pt_path.read_text()
     stub = orig_pt + (
         "\n"
-        "def _train(self, X_train, S_train, y_train, series_ids, label_dates, cfg, preprocessors=None):\n"
+        "def _train(self, X_train, S_train, M_train, y_train, series_ids, label_dates, cfg, preprocessors=None):\n"
         "    import os\n"
         "    os.makedirs(self.model_dir, exist_ok=True)\n"
         "    open(os.path.join(self.model_dir, 'patchtst.pt'), 'wb').close()\n"
@@ -47,7 +47,7 @@ def test_pipeline_patchtst(tmp_path):
         "\n"
         "PatchTSTTrainer.load=lambda self, path: None\n"
         "\n"
-        "def _predict(self, X, S, sid_idx, dyn_idx=None, static_idx=None):\n"
+        "def _predict(self, X, S, M, sid_idx, dyn_idx=None, static_idx=None):\n"
         "    k = 1.0\n"
         "    import numpy as np\n"
         "    mu = np.full((len(X), self.H), 2.0, dtype=float)\n"


### PR DESCRIPTION
## Summary
- extend preprocessing with 84-day intermittency stats
- project summary vectors as additional PatchTST patches
- plumb summary features through dataset builders and trainer

## Testing
- `pytest` *(fails: KeyboardInterrupt after 37 passed tests)*
- `pytest tests/test_pipeline_patchtst.py` *(KeyboardInterrupt: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3a0269008328810d8f0ca1046757