### PR TITLE
Use input length for patch evaluation

### DIFF
--- a/LGHackerton/tuning/patchtst.py
+++ b/LGHackerton/tuning/patchtst.py
@@ -345,8 +345,9 @@ class PatchTSTTuner(HyperparameterTuner):
                 }
                 patch_len = params["patch_len"]
                 stride = params["stride"]
-                n_patches_eval = 1 + (28 - patch_len) // stride
+                n_patches_eval = 1 + (input_len - patch_len) // stride
                 if n_patches_eval < 8:
+                    # ensure at least 8 training patches
                     raise optuna.TrialPruned()
                 params["num_workers"] = PATCH_PARAMS.get("num_workers", 0)
                 if input_len % patch_len != 0:


### PR DESCRIPTION
## Summary
- calculate `n_patches_eval` using the sampled `input_len`
- clarify pruning rule to require at least 8 training patches

## Testing
- `flake8 --max-line-length=120 LGHackerton/tuning/patchtst.py`
- `pytest tests/test_patchtst_loss_helpers.py -q`
- `pytest tests/test_pipeline_patchtst.py -q` *(fails: CalledProcessError: Command '['/root/.pyenv/versions/3.11.12/bin/python3.11', 'LGHackerton/predict.py']' returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68ab42d218b883289f633dad162e5eb0